### PR TITLE
Changed regex for PHP enable

### DIFF
--- a/scripts/setup-bootstrap.sh
+++ b/scripts/setup-bootstrap.sh
@@ -96,7 +96,7 @@ fi
 #
 if `grep '#LoadModule php5_module' /private/etc/apache2/httpd.conf > /dev/null` ; then
     echo "Enabling php... (requires sudo)"
-    sudo sed -i -e 's^#LoadModule php5_module libexec/apache2/libphp5.so^LoadModule php5_module libexec/apache2/libphp5.so^' /private/etc/apache2/httpd.conf || bail "Cannot enable php"
+    sudo sed -i -e 's^#LoadModule php5_module.*libexec/apache2/libphp5.so^LoadModule php5_module libexec/apache2/libphp5.so^' /private/etc/apache2/httpd.conf || bail "Cannot enable php"
     sudo apachectl restart || bail "Cannot restart apache"
 else
     echo "PHP already enabled... (skipping)"


### PR DESCRIPTION
Minor change, but would appreciate Hunner's eye on it to ensure I'm not undoing something he did deliberately

Changes

sudo sed -i -e 's^#LoadModule php5_module libexec/apache2/libphp5.so^LoadModule php5_module libexec/apache2/libphp5.so^' /private/etc/apache2/httpd.conf || bail "Cannot enable php"

to

sudo sed -i -e 's^#LoadModule php5_module.*libexec/apache2/libphp5.so^LoadModule php5_module libexec/apache2/libphp5.so^' /private/etc/apache2/httpd.conf  || bail "Cannot enable php"
