### PR TITLE
(#11084) Use Puppet 2.7.6 for bootstrap

### DIFF
--- a/files/centos.php
+++ b/files/centos.php
@@ -96,6 +96,7 @@ git clone http://<? echo($host . '/~' . $user); ?>/ks/mcollective.git
 cd mcollective && git remote rename origin ks && git remote add origin git://github.com/puppetlabs/marionette-collective.git && git fetch origin && git branch --set-upstream master origin/master ; cd /usr/src
 git clone http://<? echo($host . '/~' . $user); ?>/ks/puppetlabs-training-bootstrap.git
 cd puppetlabs-training-bootstrap && git remote rename origin ks && git remote add origin git@github.com:puppetlabs/puppetlabs-training-bootstrap.git && git branch --set-upstream master origin/master ; cd /usr/src
+cd /usr/src/puppet && git checkout 2.7.6
 cd /root
 RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib
 export RUBYLIB


### PR DESCRIPTION
The bootstrap script seems to use the latest version of puppet
it can find to run through our boostrap modules. This patch simply
switches to the 2.7.6 tag before running puppet apply so we're
processing our modules on the same version we run PE2 with.

Specifically, this works around the issue of Puppet >2.7.6 not
properly creating new file resources with recurse is set to true
on the /root/.vim file resource. That behavior still needs
investigation.
