### PR TITLE
We don't want /etc/puppet present

### DIFF
--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -72,4 +72,11 @@ class bootstrap {
     subscribe => File['/etc/sysconfig/network'],
     hasstatus => true,
   }
+
+  # /etc/puppet/ssl is confusing to have around. Sloppy. Kill.
+  file {'/etc/puppet':
+    ensure  => absent,
+    recurse => true,
+    force   => true,
+  }
 }

--- a/modules/learning/manifests/init.pp
+++ b/modules/learning/manifests/init.pp
@@ -20,11 +20,4 @@ class learning {
   #service { 'pe-puppet': }
   #service { 'pe-httpd': }
   #service { 'pe-activemq': }
-
-  # /etc/puppet/ssl is confusing to have around. Sloppy. Kill.
-  file {'/etc/puppet':
-    ensure  => absent,
-    recurse => true,
-    force   => true,
-  }
 }


### PR DESCRIPTION
The learning VM removes `/etc/puppet` from the puppet run, so the training VM should too.
