### PR TITLE
New ovftool has spaces in the path. Needs quoting

### DIFF
--- a/scripts/vmware2vbox.sh
+++ b/scripts/vmware2vbox.sh
@@ -16,7 +16,7 @@ DEFAULTVBNAME=${OSDIST}-${OSVER}-${PUPPETVER}-vbox
 VWNAME=${VWNAME:=${DEFAULTVWNAME}}
 VBNAME=${VBNAME:=${DEFAULTVBNAME}}
 
-${OVFTOOL} ${OVFOPS} "../${VWNAME}/${VWNAME}.vmx" "${PWD}/${VBNAME}.ovf"
+"${OVFTOOL}" ${OVFOPS} "../${VWNAME}/${VWNAME}.vmx" "${PWD}/${VBNAME}.ovf"
 
 OVFFILE=`ls "${PWD}" | grep \.ovf$`
 SED_ID='s/ovf:id="vm"/ovf:id="Puppet Training"/'


### PR DESCRIPTION
The OVF tool's new location is in `/Applications` and has spaces in the path name.
