### PR TITLE
Repo updated from "fuse-libs" -> "fuse"

### DIFF
--- a/modules/localrepo/templates/epel_pkgs.erb
+++ b/modules/localrepo/templates/epel_pkgs.erb
@@ -1,5 +1,5 @@
 fuse-sshfs
-fuse-libs
+fuse
 rrdtool-ruby
 ruby-RRDtool
 ruby-mysql


### PR DESCRIPTION
After testing, the full package is required "fuse".
