### PR TITLE
Edu bootstrap migration

### DIFF
--- a/modules/edu_bootstrap/Modulefile
+++ b/modules/edu_bootstrap/Modulefile
@@ -1,0 +1,12 @@
+name    'rcoleman-edu_bootstrap'
+version '0.0.3'
+source 'UNKNOWN'
+author 'rcoleman'
+license 'Apache License, Version 2.0'
+summary 'UNKNOWN'
+description 'UNKNOWN'
+project_page 'UNKNOWN'
+
+## Add dependencies, if any:
+dependency 'rcoleman/netatalk', '>= 0.0.2'
+dependency 'ripienaar/concat', '>= 0.1.0'

--- a/modules/edu_bootstrap/README
+++ b/modules/edu_bootstrap/README
@@ -1,0 +1,16 @@
+edu_env
+
+This is the edu_env module.
+
+License
+-------
+
+
+Contact
+-------
+
+
+Support
+-------
+
+Please log tickets and issues at our [Projects site](http://projects.example.com)

--- a/modules/edu_bootstrap/example_usage/init.pp
+++ b/modules/edu_bootstrap/example_usage/init.pp
@@ -1,0 +1,1 @@
+edu_bootstrap::user { ['ryan', 'ben', 'ralph']: }

--- a/modules/edu_bootstrap/manifests/agent.pp
+++ b/modules/edu_bootstrap/manifests/agent.pp
@@ -1,0 +1,25 @@
+class edu_bootstrap::agent {
+
+  require edu_bootstrap::repo
+
+  package { 'fuse-sshfs':
+    ensure => installed,
+  }
+
+  file { '/root/master_home':
+    ensure => directory,
+  }
+
+  file { '/etc/puppetlabs/puppet/modules':
+    ensure => 'symlink',
+    target => '/root/master_home/modules',
+  }
+
+# concat::fragment{ "apply_modulepath":
+#   target  => '/etc/puppetlabs/puppet/puppet.conf',
+#   content => "[user]\n  modulepath=/root/master_home/modules\n",
+#   order   => '02',
+#   require => Concat::Fragment['puppet_conf'],
+# }
+
+}

--- a/modules/edu_bootstrap/manifests/init.pp
+++ b/modules/edu_bootstrap/manifests/init.pp
@@ -1,0 +1,22 @@
+class edu_bootstrap {
+
+  concat{ 'puppet_conf_concat':
+    name  => '/etc/puppetlabs/puppet/puppet.conf',
+    owner => 'pe-puppet',
+    group => 'pe-puppet',
+    mode  => '0644',
+  }
+
+  concat::fragment{ 'puppet_conf':
+    target  => '/etc/puppetlabs/puppet/puppet.conf',
+    source  => '/root/puppet.conf',
+    order   => 01,
+  }
+
+  exec { 'cp_puppet_conf':
+    command => '/bin/cp /etc/puppetlabs/puppet/puppet.conf /root/puppet.conf',
+    unless  => '/usr/bin/test -f /root/puppet.conf',
+    before  => Concat::Fragment['puppet_conf'],
+  }
+
+}

--- a/modules/edu_bootstrap/manifests/master.pp
+++ b/modules/edu_bootstrap/manifests/master.pp
@@ -1,0 +1,6 @@
+class edu_bootstrap::master {
+
+  $student_array = split($::students, ',')
+  edu_bootstrap::user { $student_array: }
+
+}

--- a/modules/edu_bootstrap/manifests/repo.pp
+++ b/modules/edu_bootstrap/manifests/repo.pp
@@ -1,0 +1,31 @@
+class edu_bootstrap::repo {
+
+    if $operatingsystemrelease <= '5.12' {
+      $epelpackage = 'http://dl.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm'
+    } elsif $operatingsystemrelease >= '6.0' {
+      $epelpackage = 'http://mirror.metrocast.net/fedora/epel/6/i386/epel-release-6-7.noarch.rpm'
+    }
+    exec { 'install-epel':
+      command => "/bin/rpm -i ${epelpackage}",
+      creates => '/etc/yum.repos.d/epel.repo',
+    }
+
+    yumrepo { 'epel':
+      descr          => 'Extra Packages for Enterprise Linux 5 - $basearch',
+      enabled        => '1',
+      failovermethod => 'priority',
+      gpgcheck       => '1',
+      gpgkey         => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL',
+      mirrorlist     => 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch',
+      require        => Exec['install-epel'],
+    }
+
+    yumrepo { 'base':
+      descr      => 'CentOS-$releasever - Base',
+      enabled    => '1',
+      gpgcheck   => '1',
+      gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5',
+      mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os',
+    }
+
+}

--- a/modules/edu_bootstrap/manifests/user.pp
+++ b/modules/edu_bootstrap/manifests/user.pp
@@ -1,0 +1,45 @@
+define edu_bootstrap::user(
+  # Password defaults to puppetlabs
+  $password='$1$Tge1IxzI$kyx2gPUvWmXwrCQrac8/m0'
+) {
+
+  include edu_bootstrap
+  include concat::setup
+  include edu_bootstrap::repo
+
+  user { $name:
+    ensure   => present,
+    gid      => 'pe-puppet',
+    password => $password,
+    home     => "/home/${name}",
+  }
+
+  file { ["/home/${name}", "/home/${name}/modules"]:
+    ensure => directory,
+    owner  => $name,
+    group  => 'pe-puppet',
+    mode   => '0770',
+  }
+
+  file { "/home/${name}/site.pp":
+    ensure => file,
+    owner  => $name,
+    group  => 'pe-puppet',
+  }
+
+  concat::fragment{ "${name}_env":
+    target  => '/etc/puppetlabs/puppet/puppet.conf',
+    content => "[${name}]\n  modulepath=/home/${name}/modules:/opt/puppet/share/puppet/modules\n  manifest=/home/${name}/site.pp\n",
+    order   => '02',
+    require => Concat::Fragment['puppet_conf'],
+  }
+
+  exec { "add_console_user_${name}":
+    path    => '/opt/puppet/bin:/usr/bin',
+    cwd     => '/opt/puppet/share/console-auth',
+    command => "rake db:create_initial_admin[${name}@puppetlabs.com,puppetlabs]",
+    unless  => "test -d /home/${name}",
+    before  => File["/home/${name}"],
+  }
+
+}


### PR DESCRIPTION
Migrating @rcoleman 's  `edu_bootstrap` module from [puppet-curriculum](https://github.com/puppetlabs/puppet-curriculum) to [here](https://github.com/acidprime/puppetlabs-training-bootstrap) so we can more easily add it to the VM bootstrap process. Merged with commit history, so this commit it is mostly @rcoleman 's history and a few merge conflict tweaks.
