### PR TITLE
(#16952) - Fix fundamentals module whitespace issue

### DIFF
--- a/modules/fundamentals/manifests/init.pp
+++ b/modules/fundamentals/manifests/init.pp
@@ -30,7 +30,8 @@ class fundamentals {
       before  => Concat::Fragment['puppet_conf'],
     }
 
-    $student_array = split($::students, ',')
+    $student_normalized = regsubst($::students,'\s', '', G)
+    $student_array = split($student_normalized, ',')
     fundamentals::user { $student_array: }
 
     $class_array = split($::classes, ',')


### PR DESCRIPTION
Added a regex substring to strip whitespaces from the students parameter list
Tested locally . @casharma first pull request
