### PR TITLE
Add actual vhost.pp configuration for 11.1

### DIFF
--- a/modules/fundamentals/manifests/exercise/11/1.pp
+++ b/modules/fundamentals/manifests/exercise/11/1.pp
@@ -16,4 +16,8 @@ class fundamentals::exercise::11::1 inherits fundamentals::exercise::10::2 {
     content => template("${module_name}/exercise/${exercise_major}/${exercise_minor}/${exercise_module}/manifests/vhost.pp.erb"),
     tag     => $exercise_version,
   }
+  File ["${exercise_module}/manifests/init.pp"] {
+    content => template("${module_name}/exercise/${exercise_major}/${exercise_minor}/${exercise_module}/manifests/init.pp.erb"),
+    tag     => $exercise_version,
+  }
 }

--- a/modules/fundamentals/templates/exercise/11/1/apache/manifests/init.pp.erb
+++ b/modules/fundamentals/templates/exercise/11/1/apache/manifests/init.pp.erb
@@ -1,0 +1,38 @@
+class apache {
+  apache::vhost { "<%= @hostname %>.puppetlabs.vm":
+    port => '8080',
+    docroot => "/var/www/<%= @hostname %>",
+    notify => Service['httpd'],
+  }
+  file { "/var/www/<%= @hostname %>":
+    ensure => directory,
+  }
+  file { "/var/www/<%= @hostname %>/index.html":
+    ensure => file,
+    content => template("apache/index.html.erb"),
+  }
+  File {
+    owner => 'apache',
+    group => 'apache',
+    mode => 0644,
+  }
+  package {'httpd':
+    ensure => present,
+  }
+  service {'httpd':
+    ensure => running,
+    require => Package['httpd'],
+    subscribe => File['/var/www/html/index.html'],
+  }
+  file { '/var/www':
+    ensure => directory,
+  }
+  file { '/var/www/html':
+    ensure => directory,
+  }
+  file { '/var/www/html/index.html':
+    ensure  => file,
+    #source => 'puppet:///modules/apache/index.html',
+    content => template("apache/index.html.erb"),
+  }
+}

--- a/modules/fundamentals/templates/exercise/11/1/apache/manifests/vhost.pp.erb
+++ b/modules/fundamentals/templates/exercise/11/1/apache/manifests/vhost.pp.erb
@@ -1,38 +1,19 @@
-class apache {
-  apache::vhost { "<%= @hostname %>.puppetlabs.vm":
-    port => '8080',
-    docroot => "/var/www/<%= @hostname %>",
-    notify => Service['httpd'],
-  }
-  file { "/var/www/<%= @hostname %>":
-    ensure => directory,
-  }
-  file { "/var/www/<%= @hostname %>/index.html":
-    ensure => file,
-    content => template("apache/index.html.erb"),
-  }
-  File {
-    owner => 'apache',
-    group => 'apache',
-    mode => 0644,
-  }
-  package {'httpd':
+define apache::vhost (
+  $port,
+  $docroot,
+  $docowner,
+  $docgroup,
+  $confdir,
+  $priority = '10',
+  $options = "Indexes MultiViews",
+  $vhost_name = $name,
+  $servername = $name,
+){
+  file { "${confdir}/${name}.conf":
     ensure => present,
-  }
-  service {'httpd':
-    ensure => running,
-    require => Package['httpd'],
-    subscribe => File['/var/www/html/index.html'],
-  }
-  file { '/var/www':
-    ensure => directory,
-  }
-  file { '/var/www/html':
-    ensure => directory,
-  }
-  file { '/var/www/html/index.html':
-    ensure  => file,
-    #source => 'puppet:///modules/apache/index.html',
-    content => template("apache/index.html.erb"),
+    owner => $docowner,
+    group => $docgroup,
+    mode => '0644',
+    content => template("apache/vhost.conf.erb"),
   }
 }


### PR DESCRIPTION
This previously put the new init.pp as vhost.pp, and no vhost
configuration was actually created. This file already existed
in exercise 12.4, so I just copied it.
