### PR TITLE
adding error handling to exports.erb to handle adding further users

### DIFF
--- a/modules/fundamentals/templates/nfs/server/exports.erb
+++ b/modules/fundamentals/templates/nfs/server/exports.erb
@@ -1,6 +1,9 @@
 <% @students.split(',').each do |student| -%>
+<% begin -%>
 <% user = Etc::getpwnam(student) -%>
 <% uid  = user.uid -%>
 <% gid  = user.gid -%>
 /home/<%= student %> *(rw,insecure,all_squash,anonuid=<%= uid %>,anongid=<%= gid %>)
+<% rescue -%>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
This change just skips a line in the exports file if you have to go back and add a new user in the dashboard (without it, you have to unclassify fundamentals::nfs::server which is a pain) - with this change you skip the error, and just have to do 2 puppet applies (easiest workaround for the way the rest of the module has been written)
