### PR TITLE
Change nfs to use dns name rather than ip

### DIFF
--- a/modules/fundamentals/manifests/nfs/client.pp
+++ b/modules/fundamentals/manifests/nfs/client.pp
@@ -3,7 +3,7 @@ class fundamentals::nfs::client {
     ensure => directory,
   }
   mount { "/root/master_home":
-    device  => "${settings::server}:/home/${::hostname}",
+    device  => "${server}:/home/${::hostname}",
     fstype  => "nfs",
     ensure  => "mounted",
     options => "rw",


### PR DESCRIPTION
Change nfs to use the dns name rather than the ip. So if the puppetmaster ips change the student only needs to change it in the hosts file not the hosts file and fstab. 
