### PR TITLE
#17987 and #17980 Remove unnecessary execs and notifies

### DIFF
--- a/modules/fundamentals/manifests/exercise/10/1.pp
+++ b/modules/fundamentals/manifests/exercise/10/1.pp
@@ -1,18 +1,3 @@
 class fundamentals::exercise::10::1 inherits fundamentals::exercise::9::2 {
   $exercise_version = '10.1'
-  exec { 'facter ipaddress':
-    command   => 'facter ipaddress',
-    logoutput => true,
-    path      => '/usr/local/bin'
-  }
-  exec { 'facter operatingsystem':
-    command   => 'facter operatingsystem',
-    logoutput => true,
-    path      => '/usr/local/bin'
-  }
-  exec { 'facter':
-    command   => 'facter',
-    logoutput => true,
-    path      => '/usr/local/bin'
-  }
 }

--- a/modules/fundamentals/manifests/exercise/7/1.pp
+++ b/modules/fundamentals/manifests/exercise/7/1.pp
@@ -1,4 +1,3 @@
 class fundamentals::exercise::7::1 inherits fundamentals::exercise::6::1 {
   $exercise_version = '7.1'
-  notify { 'Login to the enterprise console and view reports': }
 }


### PR DESCRIPTION
This removes facter execs and an unneeded notify from the exercise solutions. The classes remain as empty placeholders. Discussion and the decision to do this is available in the Redmine tickets listed in the PR title.

I think some things with the exercises got shuffled around, since these are not the same classes mentioned in the tickets, but they are where the actual unneeded resources are.
