### PR TITLE
control centos base repo, enable durring capstone

### DIFF
--- a/modules/fundamentals/manifests/agent.pp
+++ b/modules/fundamentals/manifests/agent.pp
@@ -32,4 +32,15 @@ class fundamentals::agent {
         require => Host["${set_fqdn}"],
     }
   }
+
+  # Enable base repo when we are doing the capstone
+  if str2bool($::yumrepo_base_enabled) {
+    $yumrepo_base = 1
+  } else {
+    $yumrepo_base = 0
+  }
+
+  yumrepo { 'base':
+    enabled => $yumrepo_base,
+  }
 }


### PR DESCRIPTION
For a while now, enabling the centos base repo has been tribal knowledge passed down in irc/hipchat. This repo is needed for some extra packages durring the capstone. Having the class enable it by hand seems counter intuitive with the theme of the class. They could do 'puppet resource yumrepo base enabled=1,' however this still feels less than adequate.

Controlling it in the fundamentals module, we can now enable it on the console, or have the students enable it on the console. This is great for the students because it is a more "puppety" way of doing this. We should still leave this repo disabled by default for the (now more seemingly unlikely) times when we don't have an internet connection available and won't be doing the capstone. 

An eventual alternative could be to build a training vm with every conceivable package needed built in.
