### PR TITLE
#(18014) fundamentals::exercise::15::2 is missing

### DIFF
--- a/modules/fundamentals/manifests/exercise/15/2.pp
+++ b/modules/fundamentals/manifests/exercise/15/2.pp
@@ -1,0 +1,14 @@
+class fundamentals::exercise::15::2 inherits fundamentals::exercise::15::1 {
+  $exercise_major   = '15'
+  $exercise_minor   = '2'
+  $exercise_version = "${exercise_major}.${exercise_version}"
+
+  $exercise_module  = 'apache'
+
+  File ["${exercise_module}/manifests/init.pp"] {
+    content => template("${module_name}/exercise/${exercise_major}/${exercise_minor}/${exercise_module}/manifests/init.pp.erb"),
+    tag     => $exercise_version,
+  }
+
+}
+


### PR DESCRIPTION
Prior to this commit the exercise 15::2 class was missing
This commit adds a class that works wit the existing erb template
