### PR TITLE
#(13330) Remove /etc/hosts entry for puppet

### DIFF
--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -58,11 +58,6 @@ class bootstrap {
   # 1. Make sure our own hostname resolves.
   # 2. If our hostname isn't localhost.localdomain, then we had to contaminate
   #    localhost during kickstart. Restore localhost to its default state.
-  host { $::fqdn:
-    ensure       => present,
-    ip           => '127.0.0.1',
-    host_aliases => [$::hostname, "puppet.${::domain}", 'puppet'],
-  }
   if $::fqdn != 'localhost.localdomain' {
     host { 'localhost.localdomain':
       ensure       => present,


### PR DESCRIPTION
Prior to this commit, an entry for puppet was added to 127.0.0.1
This interferes with the ability of the students to be able to use the
defaults in the puppet enterprise installer in the new fundamentals
class (17436). This is a fix for ticket 13330 in redmine.
