### PR TITLE
#(18009) Update syntax mistake in 12.4

### DIFF
--- a/modules/fundamentals/templates/exercise/12/4/apache/manifests/init.pp.erb
+++ b/modules/fundamentals/templates/exercise/12/4/apache/manifests/init.pp.erb
@@ -1,18 +1,21 @@
 class apache {
   case $::osfamily {
-    'RedHat': {
-    $httpd_user = 'apache'
-    $httpd_group = 'apache'
-    $httpd_pkg = 'httpd'
-    $httpd_svc = 'httpd'
-    $httpd_conf = '/etc/httpd/conf.d'
+    RedHat': {
+      $httpd_user = 'apache'
+      $httpd_group = 'apache'
+      $httpd_pkg = 'httpd'
+      $httpd_svc = 'httpd'
+      $httpd_conf = '/etc/httpd/conf.d'
     }
-  'Debian': {
-    $httpd_user = 'www-data'
-    $httpd_group = 'www-data'
-    $httpd_pkg = 'apache2'
-    $httpd_svc = 'apache2'
-    $httpd_conf = '/etc/apache2/conf.d'
+    'Debian': {
+      $httpd_user = 'www-data'
+      $httpd_group = 'www-data'
+      $httpd_pkg = 'apache2'
+      $httpd_svc = 'apache2'
+      $httpd_conf = '/etc/apache2/conf.d'
+    }
+    default: {
+        fail("This class supports RedHat and Debian. Your osfamily is ${::osfamily}")
     }
   }
   apache::vhost { '<%= @hostname %>.puppetlabs.vm':


### PR DESCRIPTION
Prior to this commit there was a missing quote mark. This caused the
`puppet parser validate` tool to fail with the error

> puppet parser
> validate manifests/init.pp
> err: Could not parse for environment production: Could not match
> ${httpd_pkg}": at /root/master_home/modules/apache/manifests/init.pp:38
> err: Try 'puppet help parser validate' for usage
