### PR TITLE
#(8107) & #(12344) Removed RUBYLIB and PATH from bashrc file

### DIFF
--- a/modules/bootstrap/files/bashrc
+++ b/modules/bootstrap/files/bashrc
@@ -13,6 +13,3 @@ if [ -f /etc/bashrc ]; then
   . /etc/bashrc
 fi
 
-## uncomment for dev training:
-#export PATH=/usr/src/puppet/sbin:/usr/src/puppet/bin:/usr/src/facter/bin:$PATH
-#export RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib:$RUBYLIB


### PR DESCRIPTION
Prior to this commit, the root users bashrc file had commented out lines
for the previous dev training to set the RUBYLIB & PATH to the /usr/src
directory where Puppet FOSS was git cloned. This commit removes those
lines as they are no longer needed in any current training.
