### PR TITLE
#(18671) The nfs-utils package is not available on the training VM. This is

### DIFF
--- a/modules/localrepo/templates/base_pkgs.erb
+++ b/modules/localrepo/templates/base_pkgs.erb
@@ -48,3 +48,5 @@ tzdata-java
 vim
 postgresql-server
 irssi
+nfs-utils
+nfs-utils-lib


### PR DESCRIPTION
needed for the fundamentals course.
