### PR TITLE
#(18374) Packages for extending capstone.

### DIFF
--- a/modules/localrepo/templates/base_pkgs.erb
+++ b/modules/localrepo/templates/base_pkgs.erb
@@ -38,6 +38,7 @@ perl-DBD-MySQL
 perl-DBI
 perl-URI
 php
+php-mysql
 postgresql-libs
 ruby
 ruby-irb
@@ -50,3 +51,7 @@ postgresql-server
 irssi
 nfs-utils
 nfs-utils-lib
+drupal7
+drupal7-ctools
+drupal7-features
+drupal7-views


### PR DESCRIPTION
Prior to this commit the packages for the extending class were no cached
in the local repo. This commit adds those packages compared to what was
already in the VM. This is mostly I believe for the capstone lab.
