### PR TITLE
(#19509) - vsfptd package needs to be cached

### DIFF
--- a/modules/localrepo/templates/base_pkgs.erb
+++ b/modules/localrepo/templates/base_pkgs.erb
@@ -47,6 +47,7 @@ screen
 subversion
 tzdata-java
 vim
+vsftpd
 postgresql-server
 irssi
 nfs-utils


### PR DESCRIPTION
This package is needed for thias/vsftd to work in the forge lab
