### PR TITLE
Update Modulepath for Git Workflow

### DIFF
--- a/modules/fundamentals/manifests/master/repository.pp
+++ b/modules/fundamentals/manifests/master/repository.pp
@@ -21,7 +21,7 @@ define fundamentals::master::repository (
       context => "/files/etc/puppetlabs/puppet/puppet.conf/${name}",
       changes => [
         "set manifest ${envroot}/${name}/site.pp",
-        "set modulepath ${envroot}/${name}:/opt/puppet/share/puppet/modules",
+        "set modulepath ${envroot}/${name}/modules:/opt/puppet/share/puppet/modules",
       ],
     }
 


### PR DESCRIPTION
Previously, the modulepath used in the fundamentals module for the
Git workflow pointed to the user's repository directory and not the
'modules' directory contained therein.  Because of this, Puppet couldn't
find any classes.  This commit fixes that.
