### PR TITLE
adding site.pp template to allow filebucketing

### DIFF
--- a/modules/fundamentals/manifests/user.pp
+++ b/modules/fundamentals/manifests/user.pp
@@ -28,9 +28,11 @@ define fundamentals::user(
   }
 
   file { "/home/${name}/site.pp":
-    ensure => file,
-    owner  => $name,
-    group  => 'pe-puppet',
+    ensure  => file,
+    owner   => $name,
+    group   => 'pe-puppet',
+    content => template('fundamentals/site.pp.erb'),
+    replace => false,
   }
 
   concat::fragment{ "${name}_env":

--- a/modules/fundamentals/templates/site.pp.erb
+++ b/modules/fundamentals/templates/site.pp.erb
@@ -1,0 +1,6 @@
+filebucket { 'main':
+  server => '<%= @servername %>',
+  path   => false,
+}
+# Make filebucket 'main' the default backup location for all File resources:
+File { backup => 'main' }


### PR DESCRIPTION
Adding a template to turn on filebucketing by default because the console looks embarrassing when it fails to browse the old versions of files
