### PR TITLE
(#20843) Support history rewrites in the git workflow

### DIFF
--- a/modules/fundamentals/templates/post-update.erb
+++ b/modules/fundamentals/templates/post-update.erb
@@ -6,6 +6,6 @@ cd '/etc/puppetlabs/puppet/environments/<%= @name %>' || exit
 
 echo "Updating Puppet Environment <%= @name %>"
 
-git pull origin master
-#git reset --hard
+git fetch --all
+git reset --hard origin/master
 


### PR DESCRIPTION
This commit changes the post-update hook to fetch and reset, instead of
just pulling. This came about because I had students that would amend
commits or rebase, and the rewritten history would not make it to the
puppet master.
