### PR TITLE
(#96) - Updated versions, added two new modules to the cahce

### DIFF
--- a/modules/bootstrap/manifests/cache_modules.pp
+++ b/modules/bootstrap/manifests/cache_modules.pp
@@ -15,13 +15,13 @@ class bootstrap::cache_modules(
     version => '0.1.0',
   }
   bootstrap::forge { 'domcleal-augeasproviders': 
-    version => '0.5.1',
+    version => '0.7.0',
   }
   bootstrap::forge { 'cprice404-inifile': 
-    version => '0.9.0',
+    version => '0.10.3',
   }
   bootstrap::forge { 'razorsedge-vmwaretools': 
-    version => '4.2.0',
+    version => '4.4.1',
   }
   bootstrap::forge { 'hunner-wordpress': 
     version => '0.3.0',
@@ -30,17 +30,17 @@ class bootstrap::cache_modules(
     version => '0.6.1',
   }
   bootstrap::forge { 'puppetlabs-apache': 
-    version => '0.5.0-rc1',
+    version => '0.6.0',
   }
   bootstrap::forge { 'thias-vsftpd': 
-    version => '0.1.1',
+    version => '0.1.2',
   }
   bootstrap::forge { 'puppetlabs-firewall': 
-    version => '0.0.4',
+    version => '0.3.1',
   }
-  bootstrap::forge { 'saz-sudo': 
-    version => '2.1.0',
-  }
+  #  bootstrap::forge { 'saz-sudo': 
+  # version => '2.2.0',
+  #}
   bootstrap::forge { 'puppetlabs-vcsrepo': 
     version => '0.1.2',
   }
@@ -51,12 +51,18 @@ class bootstrap::cache_modules(
     version => '0.2.0',
   }
   bootstrap::forge { 'zack-irc': 
-    version => '0.0.4',
+    version => '0.0.6',
   }
   bootstrap::forge { 'hunner-charybdis': 
     version => '0.2.0',
   }
   bootstrap::forge { 'puppetlabs-puppetdb': }
+  bootstrap::forge { 'puppetlabs-apt': 
+    version => '1.1.0',
+  }
+  bootstrap::forge { 'puppetlabs-postgresql': 
+    version => '2.3.0',
+  }
   
 
   # These are the additional modules needed by the extending puppet using ruby course


### PR DESCRIPTION
- Fixes Issue #96 on github
- Versions for cached packages synced with reality
- We now also cache puppetlabs-apt and puppetlabs-postgresql
  - the above are deps for puppetdb
