### PR TITLE
Add SSH key generation at bootup

### DIFF
--- a/modules/bootstrap/files/rc.local
+++ b/modules/bootstrap/files/rc.local
@@ -5,4 +5,5 @@
 # want to do the full Sys V style init stuff.
 
 touch /var/lock/subsys/local
+/root/.ssh_keygen.sh &
 /root/.ip_info.sh &

--- a/modules/bootstrap/files/ssh_keygen.sh
+++ b/modules/bootstrap/files/ssh_keygen.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# exit if the key is already generated
+/usr/bin/test -f /root/.ssh/id_rsa && exit 0
+
+/usr/bin/ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa 2>&1 > /dev/null

--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -35,6 +35,12 @@ class bootstrap {
     source => 'puppet:///modules/bootstrap/ip_info.sh',
     mode   => 0755,
   }
+  # This script generates the initial root SSH key for the fundamentals git workflow
+  file { '/root/.ssh_keygen.sh':
+    ensure => file,
+    source => 'puppet:///modules/bootstrap/ssh_keygen.sh',
+    mode   => 0755,
+  }
   # This shouldn't change anything, but want to make sure it actually IS laid out the way I expect.
   file {'/etc/rc.local':
     ensure => symlink,


### PR DESCRIPTION
This pull adds a script that starts on bootup and pre-generates an SSH key for the student machine. This is primarily used so the student does not need to run puppet twice to get their SSH key added to the master for the Fundamentals git workflow.

This has not been tested when creating a new VM, but I did take a clean existing one and re-apply the site.pp prior to installing PE on an agent and master and testing the workflow. It does indeed result in only two Puppet runs - once to configure ~/puppetcode on the student, and once to initialize the new environment from storeconfigs on the master. 
