### PR TITLE
Add Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$user = ENV['USER']
+
+Vagrant.configure("2") do |config|
+
+
+  # Fundamentals
+  config.vm.define :master do |master_config|
+    master_config.vm.box = "master"
+    master_config.vm.box_url = "file:///Users/#{$user}/Sites/build/vagrant/centos-latest.box"
+    master_config.vm.network :private_network, ip: "10.0.0.101"
+    master_config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    master_config.vm.provision :shell,
+      :path => "scripts/master_install.sh"
+  end
+
+  config.vm.define :fundamentals do |fundamentals_config|
+    fundamentals_config.vm.box = "fundamentals"
+    fundamentals_config.vm.box_url = "file:///Users/#{$user}/Sites/build/vagrant/centos-latest.box"
+    fundamentals_config.vm.network :private_network, ip: "10.0.0.102"
+    fundamentals_config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    fundamentals_config.vm.provision :shell,
+            :path => "scripts/fundamentals_install.sh"
+  end
+
+  # Advanced
+  config.vm.define :classroom do |classroom_config|
+    classroom_config.vm.box = "classroom"
+    classroom_config.vm.box_url = "file:///Users/#{$user}/Sites/build/vagrant/centos-latest.box"
+    classroom_config.vm.network :private_network, ip: "10.0.0.201"
+    classroom_config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    classroom_config.vm.provision :shell,
+      :path => "scripts/classroom_install.sh"
+  end
+
+  config.vm.define :advanced do |advanced_config|
+    advanced_config.vm.box = "advanced"
+    advanced_config.vm.box_url = "file:///Users/#{$user}/Sites/build/vagrant/centos-latest.box"
+    advanced_config.vm.network :private_network, ip: "10.0.0.202"
+    advanced_config.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
+    advanced_config.vm.provision :shell,
+            :path => "scripts/advanced_install.sh"
+  end
+end

--- a/scripts/advanced_install.sh
+++ b/scripts/advanced_install.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+export MASTER_HOSTNAME='advanced.puppetlabs.vm'
+export CLASSROOM_HOSTNAME='classroom.puppetlabs.vm'
+
+# Setup the hostname for the system
+export RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib
+/usr/src/puppet/bin/puppet resource host "$MASTER_HOSTNAME" \
+  ensure=present \
+  host_aliases="${MASTER_HOSTNAME/.*/}" \
+  ip=`/usr/src/facter/bin/facter ipaddress`
+
+/bin/sed -i "s/HOSTNAME.*/HOSTNAME=$MASTER_HOSTNAME/" /etc/sysconfig/network
+/bin/hostname "$MASTER_HOSTNAME"
+
+# Setup master hostname
+# Might switch to this https://github.com/adrienthebo/vagrant-hosts
+/usr/src/puppet/bin/puppet resource host $CLASSROOM_HOSTNAME \
+      ensure=present \
+      host_aliases="${CLASSROOM_HOSTNAME/.*/},puppet" \
+      ip='10.0.0.201'
+
+unset RUBYLIB
+
+export q_all_in_one_install=y
+export q_database_host=localhost
+export q_database_install=y
+export q_database_port=5432
+export q_database_root_password=T3fXWQlfNDPiZA0zewA8
+export q_database_root_user=pe-postgres
+export q_install=y
+export q_pe_database=y
+export q_puppet_cloud_install=n
+export q_puppet_enterpriseconsole_auth_database_name=console_auth
+export q_puppet_enterpriseconsole_auth_database_password=AXWnz9TL0UPVB2PyOLRv
+export q_puppet_enterpriseconsole_auth_database_user=console_auth
+export q_puppet_enterpriseconsole_auth_password=puppetlabs
+export q_puppet_enterpriseconsole_auth_user_email=admin@puppetlabs.com
+export q_puppet_enterpriseconsole_database_name=console
+export q_puppet_enterpriseconsole_database_password=6A98ZMWaooJa78Eo6q5T
+export q_puppet_enterpriseconsole_database_user=console
+export q_puppet_enterpriseconsole_httpd_port=443
+export q_puppet_enterpriseconsole_install=y
+export q_puppet_enterpriseconsole_master_hostname="$MASTER_HOSTNAME"
+export q_puppet_enterpriseconsole_smtp_host=localhost
+export q_puppet_enterpriseconsole_smtp_password=
+export q_puppet_enterpriseconsole_smtp_port=25
+export q_puppet_enterpriseconsole_smtp_use_tls=n
+export q_puppet_enterpriseconsole_smtp_user_auth=n
+export q_puppet_enterpriseconsole_smtp_username=
+export q_puppet_symlinks_install=y
+export q_puppetagent_certname="$MASTER_HOSTNAME"
+export q_puppetagent_install=y
+export q_puppetagent_server="$MASTER_HOSTNAME"
+export q_puppetdb_database_name=pe-puppetdb
+export q_puppetdb_database_password=3i1YuvUqaY48ruwKmeVz
+export q_puppetdb_database_user=pe-puppetdb
+export q_puppetdb_hostname=$MASTER_HOSTNAME
+export q_puppetdb_install=y
+export q_puppetdb_port=8081
+export q_puppetmaster_certname="$MASTER_HOSTNAME"
+export q_puppetmaster_dnsaltnames="${MASTER_HOSTNAME/.*/},${MASTER_HOSTNAME},puppet,puppet.puppetlabs.vm"
+export q_puppetmaster_enterpriseconsole_hostname=localhost
+export q_puppetmaster_enterpriseconsole_port=443
+export q_puppetmaster_install=y
+export q_run_updtvpkg=n
+export q_vendor_packages_install=y
+
+# Run the master installation with an empty file given the exports above
+exec /root/puppet-enterprise/puppet-enterprise-installer -a /etc/motd

--- a/scripts/classroom_install.sh
+++ b/scripts/classroom_install.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+export MASTER_HOSTNAME='classroom.puppetlabs.vm'
+
+# Setup the hostname for the system
+export RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib
+/usr/src/puppet/bin/puppet resource host "$MASTER_HOSTNAME" \
+  ensure=present \
+  host_aliases="${MASTER_HOSTNAME/.*/}" \
+  ip=`/usr/src/facter/bin/facter ipaddress`
+unset RUBYLIB
+
+/bin/sed -i "s/HOSTNAME.*/HOSTNAME=$MASTER_HOSTNAME/" /etc/sysconfig/network
+/bin/hostname "$MASTER_HOSTNAME"
+
+export q_all_in_one_install=y
+export q_database_host=localhost
+export q_database_install=y
+export q_database_port=5432
+export q_database_root_password=T3fXWQlfNDPiZA0zewA8
+export q_database_root_user=pe-postgres
+export q_install=y
+export q_pe_database=y
+export q_puppet_cloud_install=n
+export q_puppet_enterpriseconsole_auth_database_name=console_auth
+export q_puppet_enterpriseconsole_auth_database_password=AXWnz9TL0UPVB2PyOLRv
+export q_puppet_enterpriseconsole_auth_database_user=console_auth
+export q_puppet_enterpriseconsole_auth_password=puppetlabs
+export q_puppet_enterpriseconsole_auth_user_email=admin@puppetlabs.com
+export q_puppet_enterpriseconsole_database_name=console
+export q_puppet_enterpriseconsole_database_password=6A98ZMWaooJa78Eo6q5T
+export q_puppet_enterpriseconsole_database_user=console
+export q_puppet_enterpriseconsole_httpd_port=443
+export q_puppet_enterpriseconsole_install=y
+export q_puppet_enterpriseconsole_master_hostname="$MASTER_HOSTNAME"
+export q_puppet_enterpriseconsole_smtp_host=localhost
+export q_puppet_enterpriseconsole_smtp_password=
+export q_puppet_enterpriseconsole_smtp_port=25
+export q_puppet_enterpriseconsole_smtp_use_tls=n
+export q_puppet_enterpriseconsole_smtp_user_auth=n
+export q_puppet_enterpriseconsole_smtp_username=
+export q_puppet_symlinks_install=y
+export q_puppetagent_certname="$MASTER_HOSTNAME"
+export q_puppetagent_install=y
+export q_puppetagent_server="$MASTER_HOSTNAME"
+export q_puppetdb_database_name=pe-puppetdb
+export q_puppetdb_database_password=3i1YuvUqaY48ruwKmeVz
+export q_puppetdb_database_user=pe-puppetdb
+export q_puppetdb_hostname=$MASTER_HOSTNAME
+export q_puppetdb_install=y
+export q_puppetdb_port=8081
+export q_puppetmaster_certname="$MASTER_HOSTNAME"
+export q_puppetmaster_dnsaltnames="${MASTER_HOSTNAME/.*/},${MASTER_HOSTNAME},puppet,puppet.puppetlabs.vm"
+export q_puppetmaster_enterpriseconsole_hostname=localhost
+export q_puppetmaster_enterpriseconsole_port=443
+export q_puppetmaster_install=y
+export q_run_updtvpkg=n
+export q_vendor_packages_install=y
+
+# Run the master installation with an empty file given the exports above
+exec /root/puppet-enterprise/puppet-enterprise-installer -a /etc/motd

--- a/scripts/fundamentals_install.sh
+++ b/scripts/fundamentals_install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+export AGENT_HOSTNAME='fundamentals.puppetlabs.vm'
+export MASTER_HOSTNAME='master.puppetlabs.vm'
+
+# Setup the hostname for the system
+export RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib
+/usr/src/puppet/bin/puppet resource host "$AGENT_HOSTNAME" \
+  ensure=present \
+  host_aliases="${AGENT_HOSTNAME/.*/}" \
+  ip=`/usr/src/facter/bin/facter ipaddress`
+
+/bin/sed -i "s/HOSTNAME.*/HOSTNAME=$AGENT_HOSTNAME/" /etc/sysconfig/network
+/bin/hostname "$AGENT_HOSTNAME"
+
+# Setup master hostname
+# Might switch to this https://github.com/adrienthebo/vagrant-hosts
+/usr/src/puppet/bin/puppet resource host $MASTER_HOSTNAME \
+    ensure=present \
+    host_aliases="${MASTER_HOSTNAME/.*/},puppet" \
+    ip='10.0.0.101'
+
+unset RUBYLIB
+export q_all_in_one_install=n
+export q_database_install=n
+export q_fail_on_unsuccessful_master_lookup=y
+export q_install=y
+export q_pe_database=n
+export q_puppet_cloud_install=n
+export q_puppet_enterpriseconsole_install=n
+export q_puppet_symlinks_install=y
+export q_puppetagent_certname="$AGENT_HOSTNAME"
+export q_puppetagent_install=y
+export q_puppetagent_server="$MASTER_HOSTNAME"
+export q_puppetca_install=n
+export q_puppetdb_install=n
+export q_puppetmaster_install=n
+export q_run_updtvpkg=n
+export q_vendor_packages_install=y
+
+# Run the master installation with an empty file given the exports above
+exec /root/puppet-enterprise/puppet-enterprise-installer -a /etc/motd

--- a/scripts/master_install.sh
+++ b/scripts/master_install.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+export MASTER_HOSTNAME='master.puppetlabs.vm'
+
+# Setup the hostname for the system
+export RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib
+/usr/src/puppet/bin/puppet resource host "$MASTER_HOSTNAME" \
+  ensure=present \
+  host_aliases="${MASTER_HOSTNAME/.*/}" \
+  ip=`/usr/src/facter/bin/facter ipaddress`
+unset RUBYLIB
+
+/bin/sed -i "s/HOSTNAME.*/HOSTNAME=$MASTER_HOSTNAME/" /etc/sysconfig/network
+/bin/hostname "$MASTER_HOSTNAME"
+
+export q_all_in_one_install=y
+export q_database_host=localhost
+export q_database_install=y
+export q_database_port=5432
+export q_database_root_password=T3fXWQlfNDPiZA0zewA8
+export q_database_root_user=pe-postgres
+export q_install=y
+export q_pe_database=y
+export q_puppet_cloud_install=n
+export q_puppet_enterpriseconsole_auth_database_name=console_auth
+export q_puppet_enterpriseconsole_auth_database_password=AXWnz9TL0UPVB2PyOLRv
+export q_puppet_enterpriseconsole_auth_database_user=console_auth
+export q_puppet_enterpriseconsole_auth_password=puppetlabs
+export q_puppet_enterpriseconsole_auth_user_email=admin@puppetlabs.com
+export q_puppet_enterpriseconsole_database_name=console
+export q_puppet_enterpriseconsole_database_password=6A98ZMWaooJa78Eo6q5T
+export q_puppet_enterpriseconsole_database_user=console
+export q_puppet_enterpriseconsole_httpd_port=443
+export q_puppet_enterpriseconsole_install=y
+export q_puppet_enterpriseconsole_master_hostname="$MASTER_HOSTNAME"
+export q_puppet_enterpriseconsole_smtp_host=localhost
+export q_puppet_enterpriseconsole_smtp_password=
+export q_puppet_enterpriseconsole_smtp_port=25
+export q_puppet_enterpriseconsole_smtp_use_tls=n
+export q_puppet_enterpriseconsole_smtp_user_auth=n
+export q_puppet_enterpriseconsole_smtp_username=
+export q_puppet_symlinks_install=y
+export q_puppetagent_certname="$MASTER_HOSTNAME"
+export q_puppetagent_install=y
+export q_puppetagent_server="$MASTER_HOSTNAME"
+export q_puppetdb_database_name=pe-puppetdb
+export q_puppetdb_database_password=3i1YuvUqaY48ruwKmeVz
+export q_puppetdb_database_user=pe-puppetdb
+export q_puppetdb_hostname=$MASTER_HOSTNAME
+export q_puppetdb_install=y
+export q_puppetdb_port=8081
+export q_puppetmaster_certname="$MASTER_HOSTNAME"
+export q_puppetmaster_dnsaltnames="${MASTER_HOSTNAME/.*/},${MASTER_HOSTNAME},puppet,puppet.puppetlabs.vm"
+export q_puppetmaster_enterpriseconsole_hostname=localhost
+export q_puppetmaster_enterpriseconsole_port=443
+export q_puppetmaster_install=y
+export q_run_updtvpkg=n
+export q_vendor_packages_install=y
+
+# Run the master installation with an empty file given the exports above
+exec /root/puppet-enterprise/puppet-enterprise-installer -a /etc/motd


### PR DESCRIPTION
Prior to this commit we did not have a vagrant workflow for testing
the virtual machines. This commit adds a Vagrantfile with
4 boxes that will use the box file created when you `rake
everything['Centos']`. This allows you to rebuild the vm and `vagrant up
master` and the related student system i.e. `vagrant up fundamentals`
