### PR TITLE
Update the module to ignore dynamic hosts

### DIFF
--- a/modules/advanced/manifests/init.pp
+++ b/modules/advanced/manifests/init.pp
@@ -8,9 +8,12 @@ class advanced {
     }
   }
 
-  case $::hostname {
-    'classroom': { include advanced::classroom }
-    'proxy'    : { include advanced::proxy     }
-    default    : { include advanced::agent     }
+  # Ignore the machines spun up for the provisioning & capstone labs
+  if $::domain == 'puppetlabs.vm' {
+    case $::hostname {
+      'classroom': { include advanced::classroom }
+      'proxy'    : { include advanced::proxy     }
+      default    : { include advanced::agent     }
+    }
   }
 }


### PR DESCRIPTION
Ignore all dynamically provisioned machines from the
- provisioning lab
- capstone lab

This prevents errors due to missing cached packages, etc.
