### PR TITLE
Removing deprecated use of 'fqdn'.

### DIFF
--- a/modules/bootstrap/templates/network.erb
+++ b/modules/bootstrap/templates/network.erb
@@ -1,3 +1,3 @@
 NETWORKING=yes
 NETWORKING_IPV6=yes
-HOSTNAME=<%= fqdn %>
+HOSTNAME=<%= @fqdn %>


### PR DESCRIPTION
Should be '@fqdn'.

I got this error from the logs created when setting up the VM.

http://cl.ly/image/423u4702190i
