### PR TITLE
Reverting the change that manages the license.key file

### DIFF
--- a/modules/advanced/Modulefile
+++ b/modules/advanced/Modulefile
@@ -1,5 +1,5 @@
 name    'pltraining-advanced'
-version '1.4.1'
+version '1.4.2'
 source 'https://github.com/puppetlabs/puppetlabs-training-bootstrap/tree/master/modules/advanced'
 author 'pltraining'
 license 'Apache License, Version 2.0'

--- a/modules/advanced/manifests/classroom.pp
+++ b/modules/advanced/manifests/classroom.pp
@@ -8,12 +8,6 @@ class advanced::classroom {
   # console fixes for Safari
   include advanced::classroom::console
 
-  # Write out our edu license file to prevent console noise
-  file { '/etc/puppetlabs/license.key':
-    ensure => file,
-    source => 'puppet:///modules/advanced/license.key',
-  }
-
   package { 'rubygem-sinatra':
     ensure   => present,
     before   => Class['kickstand'],

--- a/modules/fundamentals/Modulefile
+++ b/modules/fundamentals/Modulefile
@@ -1,5 +1,5 @@
 name    'pltraining-fundamentals'
-version '1.4.1'
+version '1.4.2'
 source 'https://github.com/puppetlabs/puppetlabs-training-bootstrap/tree/master/modules/fundamentals'
 author 'pltraining'
 license 'Apache License, Version 2.0'

--- a/modules/fundamentals/manifests/master.pp
+++ b/modules/fundamentals/manifests/master.pp
@@ -14,12 +14,6 @@ class fundamentals::master ( $classes = [] ) {
     require => Service['pe-httpd'],
   }
 
-  # Write out our edu license file to prevent console noise
-  file { '/etc/puppetlabs/license.key':
-    ensure => file,
-    source => 'puppet:///modules/fundamentals/license.key',
-  }
-
   package { 'git':
     ensure => present,
   }


### PR DESCRIPTION
A puppetlabs module also manages the /etc/puppet/license.key file
Leaving the file alone in the modules, so if one needs to, once can
manually copy the file to /etc/puppet - just can't do it with puppet
due to the aforementioned puppetlabs module.
