### PR TITLE
A somewhat icky way of only managing the key once.

### DIFF
--- a/modules/advanced/Modulefile
+++ b/modules/advanced/Modulefile
@@ -1,5 +1,5 @@
 name    'pltraining-advanced'
-version '1.4.1'
+version '1.4.2'
 source 'https://github.com/puppetlabs/puppetlabs-training-bootstrap/tree/master/modules/advanced'
 author 'pltraining'
 license 'Apache License, Version 2.0'

--- a/modules/advanced/manifests/classroom.pp
+++ b/modules/advanced/manifests/classroom.pp
@@ -8,10 +8,14 @@ class advanced::classroom {
   # console fixes for Safari
   include advanced::classroom::console
 
-  # Write out our edu license file to prevent console noise
-  file { '/etc/puppetlabs/license.key':
-    ensure => file,
-    source => 'puppet:///modules/advanced/license.key',
+  # This wonkiness is due to the fact that puppet_enterprise::license class
+  # manages this file only if it exists on the master. So we do the opposite.
+  if ( file('/etc/puppetlabs/license.key', '/dev/null') == undef ) {
+    # Write out our edu license file to prevent console noise
+    file { '/etc/puppetlabs/license.key':
+      ensure => file,
+      source => 'puppet:///modules/advanced/license.key',
+    }
   }
 
   package { 'rubygem-sinatra':

--- a/modules/fundamentals/Modulefile
+++ b/modules/fundamentals/Modulefile
@@ -1,5 +1,5 @@
 name    'pltraining-fundamentals'
-version '1.4.1'
+version '1.4.2'
 source 'https://github.com/puppetlabs/puppetlabs-training-bootstrap/tree/master/modules/fundamentals'
 author 'pltraining'
 license 'Apache License, Version 2.0'

--- a/modules/fundamentals/manifests/master.pp
+++ b/modules/fundamentals/manifests/master.pp
@@ -14,10 +14,14 @@ class fundamentals::master ( $classes = [] ) {
     require => Service['pe-httpd'],
   }
 
-  # Write out our edu license file to prevent console noise
-  file { '/etc/puppetlabs/license.key':
-    ensure => file,
-    source => 'puppet:///modules/fundamentals/license.key',
+  # This wonkiness is due to the fact that puppet_enterprise::license class
+  # manages this file only if it exists on the master. So we do the opposite.
+  if ( file('/etc/puppetlabs/license.key', '/dev/null') == undef ) {
+    # Write out our edu license file to prevent console noise
+    file { '/etc/puppetlabs/license.key':
+      ensure => file,
+      source => 'puppet:///modules/fundamentals/license.key',
+    }
   }
 
   package { 'git':


### PR DESCRIPTION
The `puppet_enterprise::license` class manages the license file on the
master, but only after it exists. So we do the opposite. We manage
the file, but only when it doesn't exist.

On first run, we'll manage it, but on subsequent runs PE will take over.
