### PR TITLE
Fix the hiera shortcut

### DIFF
--- a/modules/fundamentals/manifests/master/hiera.pp
+++ b/modules/fundamentals/manifests/master/hiera.pp
@@ -5,7 +5,7 @@
 # ### This is not idempotent, so don't classify the master
 #
 class fundamentals::master::hiera {
-  file { '/etc/puppetlabs/puppet/hieradata/master.puppetlabs.vm.yaml':
+  file { '/etc/puppetlabs/puppet/hieradata/defaults.yaml':
     ensure  => file,
     owner   => 'root',
     group   => 'root',


### PR DESCRIPTION
- without writing the defaults.yaml file, agent runs
  on student machines won't be able to see the existence
  of teams (if only master.puppetlabs.vm.yaml exists)
