### PR TITLE
Make training-bootstrap repo Jenkins-friendly

### DIFF
--- a/files/Centos/ks.cfg.erb
+++ b/files/Centos/ks.cfg.erb
@@ -57,7 +57,7 @@ curl
 tar
 ruby
 
-%post --erroronfail
+%post
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
@@ -76,8 +76,16 @@ hostname <%= $settings[:hostname] %>
 
 sed -i 's/127\.0\.0\.1.*/\0 <%= $settings[:hostname] %> <%= $settings[:hostname].split('.')[0] %>/' /etc/hosts
 cp /mnt/puppet/<%= $settings[:pe_tarball] %> /root/
-tar zxf /root/<%= $settings[:pe_tarball] %>
-ln -s /root/puppet-enterprise-<%= PEVERSION + $settings[:pe_install_suffix] %> /root/puppet-enterprise
+<% if File.extname($settings[:pe_tarball]) == ".gz" %>
+tar zmxf /root/<%= $settings[:pe_tarball] %>
+<% tname = File.basename($settings[:pe_tarball], ".gz") %>
+<% fname = File.basename(tname, ".tar") %>
+<% elsif File.extname($settings[:pe_tarball]) == ".tar" %>
+tar mxf /root/<%= $settings[:pe_tarball] %>
+<% fname = File.basename($settings[:pe_tarball], ".tar") %>
+<% else abort("Not sure what type of file #{$settings[:pe_tarball]} is") %>
+<% end %>
+ln -s /root/<%= fname %> /root/puppet-enterprise
 
 # put verification script links in personal bin directory
 ln -s /usr/src/puppetlabs-training-bootstrap/scripts/classroom /root/bin
@@ -94,16 +102,19 @@ cd facter && git remote rename origin ks && git remote add origin git://github.c
 git clone /mnt/puppet/hiera.git
 cd hiera && git remote rename origin ks && git remote add origin git://github.com/puppetlabs/hiera.git && git fetch origin && git branch --set-upstream master origin/master && git checkout 1.2.1 ; cd /usr/src
 git clone /mnt/puppet/puppetlabs-training-bootstrap.git
+cd puppetlabs-training-bootstrap && git checkout <%= @ptbbranch %>
 cd /root
 RUBYLIB=/usr/src/puppet/lib:/usr/src/facter/lib:/usr/src/hiera/lib
 export RUBYLIB
-/usr/src/puppet/bin/puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/site.pp
+/usr/src/puppet/bin/puppet apply --modulepath=/usr/src/puppetlabs-training-bootstrap/modules --verbose /usr/src/puppetlabs-training-bootstrap/manifests/site.pp || /usr/bin/true
 # Cleanup from the puppet run
 rm -rf /var/lib/puppet
 # Ensure ethernet interface is still eth0
 rm -rf /etc/udev/rules.d/70-persistent-net.rules
 sed -i -e '/^HWADDR.*/d' /etc/sysconfig/network-scripts/ifcfg-eth0
+cp /usr/src/puppetlabs-training-bootstrap/files/registerdns.sh /etc/rc3.d/S16registerdns.sh
 #/bin/sh
 #echo 'Hello, World!'
 ) 2>&1 | /usr/bin/tee /root/post.log
+cp /root/post.log /boot
 chvt 1

--- a/files/dnsconfig.sh
+++ b/files/dnsconfig.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+dhcp_hostname="learn"

--- a/files/registerdns.sh
+++ b/files/registerdns.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+## If a file called dnsconfig.sh exists in /boot (put there by the
+## ship rake task), source it
+## and use the variables to set dynamic DNS registration
+## information, grab the puppetlabs public keys for root's 
+## authorized_keys file, then delete dnsconfig.sh and this file. If it doesn't
+## exist, then just delete this script and exit.
+
+## This is intended to support publishing the learning VM
+## to our local VMware environment without changing the
+## config for end-users. 
+
+get_ssh_keys ()
+{ 
+
+## This is the manage_root_authorized_keys script from puppetlabs-sshkeys
+
+set -u
+
+# MAKE SURE THIS IS SSL!
+URL="https://raw.github.com/puppetlabs/puppetlabs-sshkeys/master/templates/ssh/authorized_keys"
+
+if [[ `uname` == CYGWIN* ]]
+    then
+    OWNER="Administrator"
+    GROUP="None"
+    SSH_HOME=~Administrator/.ssh/
+else
+    OWNER="0"
+    GROUP="0"
+    SSH_HOME=~root/.ssh/
+fi
+
+if which curl 2>&1 >/dev/null
+    then
+    GET="curl --silent -o - ${URL}"
+else
+    GET="wget -q -O - ${URL}"
+fi
+
+if ! [[ -d $SSH_HOME ]]
+    then
+    mkdir $SSH_HOME
+    chmod 700 $SSH_HOME
+    chown $OWNER:$GROUP $SSH_HOME
+fi
+
+# Make sure there is no temporary file
+if [[ -f $SSH_HOME/authorized_keys.tmp ]]
+    then
+    rm -f $SSH_HOME/authorized_keys.tmp
+fi
+
+# This should be gone now.
+if ! [[ -f $SSH_HOME/authorized_keys.tmp ]]
+    then
+    touch $SSH_HOME/authorized_keys.tmp
+    chmod 644 $SSH_HOME/authorized_keys.tmp
+    chown $OWNER:$GROUP $SSH_HOME/authorized_keys.tmp
+fi
+
+# Download the file.  Abort without modifying ~/.ssh/authorized_keys if this
+# step fails.
+$GET > $SSH_HOME/authorized_keys.tmp
+rval=$?
+if [[ $rval -ne 0 ]]; then
+    echo "Error: Download failed with exit status code $rval"
+    exit 1
+fi
+
+# Merge any local authorized_keys
+# Make sure there is no temporary file
+if [[ -f $SSH_HOME/authorized_keys.local ]]
+    then
+    cp -p $SSH_HOME/authorized_keys.{tmp,downloaded}
+    cat $SSH_HOME/authorized_keys.{local,downloaded} | sort | uniq > $SSH_HOME/authorized_keys.tmp
+fi
+
+# Now move the file into place.  POSIX rename is atomic.
+mv -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys
+
+}
+
+
+me=$(readlink -f $0)
+
+if [ -f /boot/dnsconfig.sh ]; then
+    . /boot/dnsconfig.sh
+    yum install -y open-vm-tools
+    echo "DHCP_HOSTNAME=$dhcp_hostname" >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    get_ssh_keys
+    rm /boot/dnsconfig.sh
+    rm $me
+    /sbin/reboot    
+else
+    rm $me
+fi

--- a/modules/learning/manifests/install.pp
+++ b/modules/learning/manifests/install.pp
@@ -2,7 +2,7 @@ class learning::install {
   exec {'install-pe':
     command     => "/root/puppet-enterprise/puppet-enterprise-installer -D -a /root/learning.answers",
     logoutput   => true,
-    timeout     => '1800',
+    timeout     => '14400',
     environment => "RUBYLIB=''",
     # If you don't reset the rubylib, it'll inherit the one used during kickstart and the installer will blow up.
   }
@@ -13,6 +13,7 @@ class learning::install {
     logoutput   => true,
     environment => "RUBYLIB=''",
     require     => Exec['install-pe'],
+    timeout     => '14400',
   }
 
   # So we'll make sure it exists:
@@ -23,21 +24,22 @@ class learning::install {
     environment => "RUBYLIB=''",
     require     => Exec['install-pe'],
     before      => Exec['reduce-activemq-heap'],
+    timeout     => '14400',
   }
 
   # Add script that can print console login. Bootstrap will optionally call this in the rc.local file.
   file {'/root/.console_login.sh':
     ensure => file,
     source => 'puppet:///modules/learning/console_login.sh',
-    mode   => 0755,
+    mode   => '0755',
   }
 
   # Put examples in place -- we should have some way to automatically get the
   # most recent from the puppet docs source, where they'll be in
   # source/learning/files/examples.
   file {'/root/examples':
-    ensure => directory,
-    source => "puppet:///modules/$module_name/examples",
+    ensure  => directory,
+    source  => "puppet:///modules/${module_name}/examples",
     recurse => true,
   }
 


### PR DESCRIPTION
This commit aims to make the puppetlabs-training-bootstrap repo
jenkins-friendly without significantly altering existing functionality.
The goal is that it continue to work for existing users without
altering their current workflow.

This parameterizes all of the inputs to allow them to be set via environment
variable. Logic has also been added to work around minor command and path
differences between Mac and Linux.

This adds a function to automatically get the most recent internal test
version of PE if the PESTATUS environment variable is set to 'latest'.

Other updates have been made to the CentOS kickstart to work
with the above modifications. A script that runs on first boot has
been injected that will handle setting up the DNS and SSH keys to
use internally on the VM that gets published to our internal
VMWare infrastructure. This script does nothing and deletes
itself in any other scenario.

I did have to set huge timeouts in the execs that install PE
on the learning VM because the builder environment is slow.

None of these changes or additions should materially affect
the content or functionality of the generated VM in any way.
