### PR TITLE
Enable remote repos at a lower priority

### DIFF
--- a/modules/localrepo/manifests/repobuild.pp
+++ b/modules/localrepo/manifests/repobuild.pp
@@ -26,7 +26,6 @@
 #   }
 
 define localrepo::repobuild ($repopath, $repoer = "createrepo", $repoops = "-C -p") {
-
   exec { "${name}_build":
     command     => "${repoer} ${repoops} ${repopath}",
     user        => root,
@@ -34,10 +33,12 @@ define localrepo::repobuild ($repopath, $repoer = "createrepo", $repoops = "-C -
     path        => "/usr/bin:/bin",
     refreshonly => true,
   }
-
-  file { "/etc/yum.repos.d/${name}.repo":
-    content => "[${name}]\nname=Locally stored packages for ${name}\nbaseurl=file://${repopath}\nenabled=1\ngpgcheck=0",
+  yumrepo { $name:
+    descr    => "Locally stored packages for ${name}",
+    enabled  => '1',
+    baseurl  => "file://${repopath}",
+    gpgcheck => '0',
+    priority => '10',
     require => Exec["${name}_build"],
   }
-
 }

--- a/modules/localrepo/templates/base_pkgs.erb
+++ b/modules/localrepo/templates/base_pkgs.erb
@@ -66,3 +66,4 @@ drupal7-views
 tree
 lynx
 elinks
+yum-plugin-priorities

--- a/modules/training/manifests/init.pp
+++ b/modules/training/manifests/init.pp
@@ -1,25 +1,20 @@
 class training {
-  # puppetmaster bluetooth training
-  service { 'hidd':
-    ensure => stopped,
-    enable => false,
-    # hasstatus => broken
-  } ->
-  package { 'bluez-utils':
-    ensure => absent,
-  } ->
-  package { 'bluez-libs':
-    ensure => absent,
-  }
-
   # training repos
   yumrepo { 'puppetlabs':
     baseurl  => 'http://yum.puppetlabs.com/base/',
-    enabled  => '0',
+    enabled  => '1',
+    priority => '99',
     gpgcheck => '0',
     descr    => 'Puppetlabs yum repo'
   }
+  augeaus { 'enable_yum_priorities':
+    context => '/files/etc/yum/pluginconf.d/priorities.conf/main',
+    changes => [
+      "set enabled 1",
+    ],
+  }
   yumrepo { ['epel', 'updates', 'base', 'extras']:
-    enabled => 0,
+    enabled  => '1',
+    priority => '99',
   }
 }


### PR DESCRIPTION
This will enable the yum repos at a lower priority than the
  local cache repo.
Also removed some old bluez-utils stuff we don't use/need.
