### PR TITLE
Adding screen and zsh to packages the kickstart installs.

### DIFF
--- a/files/Centos/ks.cfg.erb
+++ b/files/Centos/ks.cfg.erb
@@ -52,10 +52,12 @@ poweroff
 %packages
 @Core
 @base
-ntp
 curl
-tar
+ntp
 ruby
+screen
+tar
+zsh
 
 %post
 exec < /dev/tty3 > /dev/tty3


### PR DESCRIPTION
As a convenience, add screen and zsh to the kickstart install.
