### PR TITLE
Updating vmos and vmtype validation to ignore when they're null.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,12 +38,12 @@ else
 end
 
 # Bail politely when handed a 'vmos' that's not supported.
-if ENV['vmos'] !~ /^(Centos|Debian)$/
+if ENV['vmos'] && ENV['vmos'] !~ /^(Centos|Debian)$/
   abort("ERROR: Unrecognized vmos parameter: #{ENV['vmos']}")
 end
 
 # Bail if handed a 'vmtype' that's not supported.
-if ENV['vmtype'] !~ /^(training|learning)$/
+if ENV['vmtype'] && ENV['vmtype'] !~ /^(training|learning)$/
   abort("ERROR: Unrecognized vmtype parameter: #{ENV['vmtype']}")
 end
 


### PR DESCRIPTION
Error in my error-checking.  Some rake tasks, such as 'clean,' don't require a vmos or vmtype.  Updated logic only checks the validity of those variables if they exist in the first place.  Tasks that do require them to exist already prompt for a value in that case.
