### PR TITLE
Install yum-plugin-priorities

### DIFF
--- a/modules/training/manifests/init.pp
+++ b/modules/training/manifests/init.pp
@@ -7,11 +7,15 @@ class training {
     gpgcheck => '0',
     descr    => 'Puppetlabs yum repo'
   }
+  package { 'yum-plugin-priorities':
+    ensure => installed,
+  }
   augeas { 'enable_yum_priorities':
     context => '/files/etc/yum/pluginconf.d/priorities.conf/main',
     changes => [
       "set enabled 1",
     ],
+    require => Package['yum-plugin-priorities'],
   }
   yumrepo { ['epel', 'updates', 'base', 'extras']:
     enabled  => '1',


### PR DESCRIPTION
In order to use yum priorities, the 'yum-plugin-priorities' package needs
to be installed (ref:
http://wiki.centos.org/PackageManagement/Yum/Priorities). This commit adds
a package resource to do just that.
