### PR TITLE
Add a defined type to manage group class params

### DIFF
--- a/modules/fundamentals/manifests/console/groupparam.pp
+++ b/modules/fundamentals/manifests/console/groupparam.pp
@@ -1,0 +1,21 @@
+define fundamentals::console::groupparam (
+  $group,
+  $class,
+  $param,
+  $value,
+  $force = false,
+) {
+    $guard = $force ? {
+      true  => undef,
+      false => "rake nodegroup:listclassparams name=${group} class=${class} | grep ${param}",
+    }
+
+    exec { "add_console_group_param_${name}":
+      path        => '/opt/puppet/bin:/bin',
+      cwd         => '/opt/puppet/share/puppet-dashboard',
+      environment => 'RAILS_ENV=production',
+      command     => "rake nodegroup:addclassparam name=${group} class=${class} param=${param} value=${value}",
+      unless      => $guard,
+    }
+
+}

--- a/modules/fundamentals/tests/console_groupparam.pp
+++ b/modules/fundamentals/tests/console_groupparam.pp
@@ -1,0 +1,6 @@
+fundamentals::console::groupparam { 'activemq_heap_mb':
+  group => 'puppet_master',
+  class => 'pe_mcollective::role::master',
+  param => 'activemq_heap_mb',
+  value => '1024',
+}


### PR DESCRIPTION
With this, we can set params on classes assigned to a group. I
anticipate using it to tune ActiveMQ when we get the testing
network built.
