### PR TITLE
Fix the dependency install problem caused by rpm.

### DIFF
--- a/scripts/classroom/setup_ruby_primer.sh
+++ b/scripts/classroom/setup_ruby_primer.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 if [ ! -f /root/.extendingrc ]; then
   echo "Installing the Puppet Enterprise ruby packages."
-  for i in $(ls /root/puppet-enterprise/packages/el-6-i386/pe-ruby*);
-  do
-    rpm -Uvh $i;
-  done
-  for i in $(ls /root/puppet-enterprise/packages/el-6-i386/pe-ruby*);
-  do
-    rpm -Uvh $i;
-  done
+  yum localinstall --disablerepo=* /root/puppet-enterprise/packages/el-6-i386/pe-ruby*
   touch .extendingrc
   echo "Please run 'exec bash' or 'exec zsh' to update your PATH."
 else


### PR DESCRIPTION
Using yum localinstall --disablerepo=\* allows the files inside the
packages directory to be installed with their correct dependencies.
