### PR TITLE
Cache the agent installer for pe_repo

### DIFF
--- a/files/Centos/ks.cfg.erb
+++ b/files/Centos/ks.cfg.erb
@@ -89,6 +89,11 @@ tar mxf /root/<%= $settings[:pe_tarball] %>
 ln -s /root/<%= fname %> /root/puppet-enterprise
 rm -f /root/<%= $settings[:pe_tarball] %>
 <% end %>
+
+# Cache agent tarball for pe_repo
+mkdir -p /usr/src/installer
+cp /mnt/puppet/<%= $settings[:agent_tarball] %> /usr/src/installer/
+
 # put verification script links in personal bin directory
 ln -s /usr/src/puppetlabs-training-bootstrap/scripts/classroom /root/bin
 

--- a/modules/userprefs/Modulefile
+++ b/modules/userprefs/Modulefile
@@ -1,5 +1,5 @@
 name    'pltraining-userprefs'
-version '0.0.1'
+version '0.0.2'
 source 'https://github.com/puppetlabs/puppetlabs-training-bootstrap/tree/master/modules/userprefs'
 author 'pltraining'
 license 'Apache License, Version 2.0'

--- a/modules/userprefs/files/shell/bashrc
+++ b/modules/userprefs/files/shell/bashrc
@@ -1,13 +1,12 @@
 # Source global definitions
-if [ -f /etc/bashrc ]; then
-  . /etc/bashrc
-fi
+[[ -f /etc/bashrc ]] && source /etc/bashrc
 
 # load customizations, such as the pretty git prompt.
 # comment this out to use your own customizations.
-if [ -f /root/.bashrc.puppet ]; then
-  . /root/.bashrc.puppet
-fi
+[[ -f ~/.bashrc.puppet ]] && source ~/.bashrc.puppet
+
+# Pull in customizations
+[[ -f ~/.profile ]] && source ~/.profile
 
 if [ -f /root/.extendingrc ]; then
   export PATH=/opt/puppet/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin

--- a/modules/userprefs/files/shell/profile
+++ b/modules/userprefs/files/shell/profile
@@ -6,6 +6,9 @@ alias mv='mv -i'
 alias vi=vim
 #export TERM=ansi
 
+# Point the PE installer to the cached agent installer
+export q_tarball_server="/usr/src/installer/"
+
 validate_yaml() {
   ruby -ryaml -e "YAML.load_file '$1'"
 }


### PR DESCRIPTION
This is not tested on versions <3.2.0, but as we aren't catching
download errors it should simply display warnings instead of failing.
