### PR TITLE
Add diff-filter to pre-commit hook

### DIFF
--- a/modules/fundamentals/files/pre-commit
+++ b/modules/fundamentals/files/pre-commit
@@ -10,7 +10,7 @@ git diff --full-index --binary > /tmp/stash.$$
 git stash -q --keep-index
 
 EXITCODE=0
-for file in `git diff-index --cached --name-only HEAD`
+for file in `git diff-index --cached --diff-filter=AM --name-only HEAD`
 do
   echo "Validating ${file}..."
 


### PR DESCRIPTION
Starting in Puppet 3.4.x the `puppet parser validate` command will throw
an error when run against a file that does not exist. The pre-commit
hook used for the fundamentals class runs all modified '.pp' files through
`parser validate` regardless of their state in git. With the new
restrictions in Puppet 3.4.x, this hook will prevent any commit
containing removed '.pp' files from succeeding.

This commit will limit the files being checked by the hook to added and
modified files only. This will allow students to remove '.pp' files.
