### PR TITLE
Updating for release 2.5

### DIFF
--- a/version.yaml
+++ b/version.yaml
@@ -1,3 +1,3 @@
 ---
 :major: 2
-:minor: 4
+:minor: 5


### PR DESCRIPTION
PE 3.2.1 based VMs.

There was no VM version 2.4 released for consumption.
