### PR TITLE
Remove puppetlabs repo, fixes TRAINVM-80.

### DIFF
--- a/modules/kickstand/files/kickstand/share/views/mirror.erb
+++ b/modules/kickstand/files/kickstand/share/views/mirror.erb
@@ -9,9 +9,3 @@ name=EPEL mirrored on the master
 baseurl=http://<%= @serverip %>:<%= @serverport %>/yum/epel/6/local/i386
 enabled=1
 gpgcheck=0
-
-[puppetlabs-enterprise-extras_local]
-name=puppetlabs-enterprise-extras mirrored on the master
-baseurl=http://<%= @serverip %>:<%= @serverport %>/yum/puppetlabs-enterprise-extras/6/local/i386
-enabled=1
-gpgcheck=0


### PR DESCRIPTION
I’ve removed the puppetlabs-enterprise-extras to fix TRAINVM-80. We’ve
removed it from the rest of the material since it is no longer needed.
