### PR TITLE
(maint) Remove --compress option from ovftool

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -426,7 +426,7 @@ task :createvmx, [:vmos] => [:createovf] do |t,args|
   cputs "Converting OVF to VMX..."
   FileUtils.rm_rf("#{VMWAREDIR}/#{$settings[:vmname]}-vmware") if File.directory?("#{VMWAREDIR}/#{$settings[:vmname]}-vmware")
   FileUtils.mkdir_p("#{VMWAREDIR}/#{$settings[:vmname]}-vmware")
-  system("'#{@ovftool_default}' --lax --compress=9 --targetType=VMX '#{OVFDIR}/#{$settings[:vmname]}-ovf/#{$settings[:vmname]}.ovf' '#{VMWAREDIR}/#{$settings[:vmname]}-vmware'")
+  system("'#{@ovftool_default}' --lax --targetType=VMX '#{OVFDIR}/#{$settings[:vmname]}-ovf/#{$settings[:vmname]}.ovf' '#{VMWAREDIR}/#{$settings[:vmname]}-vmware'")
 
   cputs 'Changing virtualhw.version = to "8"'
   # this path is different on OSX


### PR DESCRIPTION
The --compress option to ovftool results in a vmdk file that is
exactly the same size as without, and prevents vmware-mount from
being able to read the file.

This change does not appear to result in a file that is any larger.
