### PR TITLE
Fix Heartbleed vulnerability on Training VM.

### DIFF
--- a/files/Centos/ks.cfg.erb
+++ b/files/Centos/ks.cfg.erb
@@ -74,6 +74,8 @@ EOF
 sed -i 's/HOSTNAME.*/HOSTNAME=<%= $settings[:hostname] %>/' /etc/sysconfig/network
 hostname <%= $settings[:hostname] %>
 
+yum upgrade openssl -y
+
 sed -i 's/127\.0\.0\.1.*/\0 <%= $settings[:hostname] %> <%= $settings[:hostname].split('.')[0] %>/' /etc/hosts
 cp /mnt/puppet/<%= $settings[:pe_tarball] %> /root/
 <% if $settings[:vmtype] == "learning" %>


### PR DESCRIPTION
This is an ugly hack that will have to do until there is a new ISO.
It's early enough in the kickstart to mitigate any risk of any actual
information being compromised (not that there's anything sensitive here).
