### PR TITLE
disable upstream repos

### DIFF
--- a/modules/bootstrap/manifests/init.pp
+++ b/modules/bootstrap/manifests/init.pp
@@ -24,7 +24,7 @@ class bootstrap ($print_console_login = false) {
     require => Package['yum-plugin-priorities'],
   }
   yumrepo { ['epel', 'updates', 'base', 'extras']:
-    enabled  => '1',
+    enabled  => '0',
     priority => '99',
   }
 


### PR DESCRIPTION
Until we have a real fix for this, we have to disable the repositories
or we will continue to have classroom disasters. You can always
re-enable this after PE is installed and running.
