### PR TITLE
add timeout param

### DIFF
--- a/modules/advanced/templates/irc.yaml.erb
+++ b/modules/advanced/templates/irc.yaml.erb
@@ -4,6 +4,7 @@
 :irc_join: true
 :irc_ssl: false
 :irc_register_first: true
+:timeout: 30
 :report_url: https://classroom.puppetlabs.vm/nodes/%h
 #:github_token: 'token'
 #:github_user: 'user'


### PR DESCRIPTION
When James merges my PR, this will extend the IRC report processor
timeout to compensate for the often buggered up classroom networks we
deal with. In the meantime, this param won't break anything.

Safe to merge.
