### PR TITLE
Cache the unixODBC package.

### DIFF
--- a/modules/localrepo/templates/base_pkgs.erb
+++ b/modules/localrepo/templates/base_pkgs.erb
@@ -66,6 +66,7 @@ subversion
 telnet
 tree
 tzdata-java
+unixODBC
 vim
 virt-what
 vsftpd


### PR DESCRIPTION
The installer needs this package so let’s make sure it is cached.
