### PR TITLE
cache the nano package

### DIFF
--- a/modules/localrepo/templates/base_pkgs.erb
+++ b/modules/localrepo/templates/base_pkgs.erb
@@ -37,6 +37,7 @@ lynx
 mod_ssl
 mysql
 mysql-server
+nano
 nc
 neon
 nfs-utils


### PR DESCRIPTION
It's installed by default, but cache in case the student removes it for
the userprefs lab.
