### PR TITLE
Validate only new/modified files

### DIFF
--- a/modules/classroom/files/pre-commit
+++ b/modules/classroom/files/pre-commit
@@ -10,7 +10,7 @@ git diff --full-index --binary > /tmp/stash.$$
 git stash -q --keep-index
 
 EXITCODE=0
-for file in `git diff-index --cached --diff-filter=AM --name-only HEAD`
+for file in `git diff-index --cached --diff-filter=AM --name-only --diff-filter=AM HEAD`
 do
   echo "Validating ${file}..."
 

--- a/modules/fundamentals/files/pre-commit
+++ b/modules/fundamentals/files/pre-commit
@@ -10,7 +10,7 @@ git diff --full-index --binary > /tmp/stash.$$
 git stash -q --keep-index
 
 EXITCODE=0
-for file in `git diff-index --cached --diff-filter=AM --name-only HEAD`
+for file in `git diff-index --cached --diff-filter=AM --name-only --diff-filter=AM HEAD`
 do
   echo "Validating ${file}..."
 


### PR DESCRIPTION
This prevents the hook from barfing on deleted files, which is now a
thing because `puppet parser validate` properly cares about nonexistent
files now.

Fixes #271
