### PR TITLE
power_spec.rb: work with latest puppetlabs-apache

### DIFF
--- a/modules/learning/files/.testing/spec/localhost/power_spec.rb
+++ b/modules/learning/files/.testing/spec/localhost/power_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Module puppetlabs-apache" do
   it 'should be installed' do 
     file('/etc/puppetlabs/puppet/modules/apache').should be_directory
-    file('/etc/puppetlabs/puppet/modules/apache/Modulefile').should contain "name 'puppetlabs-apache'"
+    file('/etc/puppetlabs/puppet/modules/apache/metadata.json').should contain '"name": "puppetlabs-apache"'
   end
 end
 


### PR DESCRIPTION
Modulefile no longer exists in puppetlabs-apache, check metadata.json
instead.

Signed-off-by: Scott Garman sgarman@zenlinux.com
