### PR TITLE
(COURSES-317) Cached puppetlabs/mysql modules old

### DIFF
--- a/modules/bootstrap/manifests/cache_modules.pp
+++ b/modules/bootstrap/manifests/cache_modules.pp
@@ -30,7 +30,7 @@ class bootstrap::cache_modules(
     version => '0.4.0',
   }
   bootstrap::forge { 'puppetlabs-mysql':
-    version => '0.9.0',
+    version => '2.3.1',
   }
   bootstrap::forge { 'puppetlabs-apache':
     version => '0.8.1',


### PR DESCRIPTION
The course materials in ciruclation today refer to the new mysql_\* types
in the more recent version(s) of the puppetlabs/mysql module. When
performing a class with internet access, there is no issue, as the
Puppet Module Tool can reach the internet. However, when teaching a
class with limited Internet connectivity, the cached version of the
module is too old to be effective.

This commit will set the cached version of the puppetlabs/mysql module
to the 2.3.1, which is the most recent release at this time.

This version has already been tested in the field since this is the
version that would be downloaded in classes with Internet access today.
