### PR TITLE
Disable environment caching for fundamentals

### DIFF
--- a/modules/fundamentals/manifests/master.pp
+++ b/modules/fundamentals/manifests/master.pp
@@ -32,6 +32,15 @@ class fundamentals::master ( $classes = [] ) {
     ensure => directory,
   }
 
+  # Ensure the environment cache is disabled and restart if needed
+  augeas {'puppet.conf.main':
+    context => '/files/etc/puppetlabs/puppet/puppet.conf/main',
+    changes => [
+      "set environment_timeout 0",
+    ],
+    notify  => Service['pe-httpd'],
+  }
+
   # Ensure that storeconfigs are enabled and restart if needed
   augeas {'puppet.conf.master':
     context => '/files/etc/puppetlabs/puppet/puppet.conf/master',


### PR DESCRIPTION
Use the 'environment_timeout' setting to disable environment caching by
setting it to 0.  Since we are rapidly iterating code in the
Fundamentals course, this ensures there's no delay in compiling and
applying the expected catalog.

The default value is "3m", which may cause stale catalogs, delays, and
confusion.

This applies to the 'main' section of puppet.conf.  It should apply to
each student environment as well as the default 'production' environment
for the initial setup of the classroom.
