### PR TITLE
Fix the regex so bad hostnames don't blow up

### DIFF
--- a/modules/classroom/manifests/params.pp
+++ b/modules/classroom/manifests/params.pp
@@ -36,7 +36,7 @@ class classroom::params {
   }
   else {
     $role = $hostname ? {
-      /master|classroom/ => 'master',
+      /^master|classroom$/ => 'master',
       'proxy'            => 'proxy',
       default            => 'agent'
     }


### PR DESCRIPTION
This came up on the first public delivery because someone used the name
of '$studentname-master'
