### PR TITLE
Add a shell helper for demos/presentations

### DIFF
--- a/scripts/classroom/alwaysontop.sh
+++ b/scripts/classroom/alwaysontop.sh
@@ -1,6 +1,14 @@
 #! /bin/bash
 # Peter Swire - swirepe.com
 # https://github.com/swirepe/alwaysontop
+
+# bail early if we're not running bash
+if [[ ! $(ps -p $$ -ocomm= | sed 's/-//') =~ bash$ ]]
+then
+  echo "This utility currently only runs on bash."
+  return
+fi
+
 export PS1
 export PROMPT_COMMAND
 


### PR DESCRIPTION
This will keep your bash/zsh prompt at the top of the screen.
It's useful for presentations and demonstrations.

Other features:
- clears the screen automatically with each command run
- lists directory contents when entering them (abbreviated if needed)
- shows the git or svn status in directories that have them

Run the commands autotop and unautotop to enable or disable.
