### PR TITLE
Configure irssi & hosts on the master and student

### DIFF
--- a/modules/classroom/manifests/course/architect.pp
+++ b/modules/classroom/manifests/course/architect.pp
@@ -24,16 +24,20 @@ class classroom::course::architect (
 
     # prepare mcollective certs & config for syncronization
     include classroom::mcollective::master
+
+    # Include the Irssi setup and collect all hosts
+    include classroom::agent::irc
+    include classroom::agent::hosts
   }
   elsif $role == 'agent' {
     # synchronize mcollective certs & config to client node
     include classroom::mcollective::client
     include classroom::agent::r10k
     include classroom::master::reporting_tools
-  }
 
-  # Everyone gets Irssi
-  include classroom::agent::irc
-  include classroom::agent::hosts
+    # Include the Irssi setup and collect all hosts
+    include classroom::agent::irc
+    include classroom::agent::hosts
+  }
 }
 


### PR DESCRIPTION
This avoids the proxy resource duplication and avoids over classifying
the student's secondary nodes.

Thanks to @glarizza for finding it.
