### PR TITLE
Remove redundant 'mkdir -p' since second line does it, too.

### DIFF
--- a/files/Centos/ks.cfg.erb
+++ b/files/Centos/ks.cfg.erb
@@ -93,7 +93,6 @@ rm -f /root/<%= $settings[:pe_tarball] %>
 <% end %>
 
 # Cache agent tarball for pe_repo
-mkdir -p /usr/src/installer
 mkdir -p /usr/src/installer/<%= @real_pe_ver %>
 cp /mnt/puppet/<%= $settings[:agent_tarball] %> /usr/src/installer/<%= @real_pe_ver %>/
 


### PR DESCRIPTION
This commit removes one of the `mkdir -p` lines, since the second one obviates the first one.
