### PR TITLE
Supply -u flag so ntpdate uses unprivileged port.

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -50,7 +50,7 @@ check_success "Setting hostname on boot"                            \
       "$(sed -i "s/^HOSTNAME=.*$/HOSTNAME=${username}.puppetlabs.vm/" /etc/sysconfig/network 2>&1)"
 
 check_success "Synchronizing time with the classroom master"        \
-      "$(ntpdate master.puppetlabs.vm 2>&1)"
+      "$(ntpdate -u master.puppetlabs.vm 2>&1)"
 
 if [ $ERRORCOUNT -eq 0 ]
 then


### PR DESCRIPTION
This commit adds the -u flag to ntpdate, so that it will use an unprivileged port.  This is necessary on systems that already have ntpd running, so that ntpdate won't try to grab the official ntp port.
