### PR TITLE
Change irc host_alias to puppetlabs.vm

### DIFF
--- a/modules/classroom/manifests/proxy.pp
+++ b/modules/classroom/manifests/proxy.pp
@@ -30,7 +30,7 @@ class classroom::proxy {
 
   @@host { $::fqdn:
     ensure       => present,
-    host_aliases => [$::hostname, 'irc.classroom.vm'],
+    host_aliases => [$::hostname, 'irc.puppetlabs.vm'],
     ip           => $::ipaddress,
     tag          => 'classroom'
   }


### PR DESCRIPTION
The classroom::proxy class when applied to the proxy/irc server exports a host resource for itself.  The module makes one of the host_aliases irc.classroom.vm.  This should be irc.puppetlabs.vm.  This commit fixes that.
