### PR TITLE
Reword test to clarify master resolves *and* is pingable.

### DIFF
--- a/scripts/classroom/verify_classroom.sh
+++ b/scripts/classroom/verify_classroom.sh
@@ -24,7 +24,7 @@ check "grep HOSTNAME=${NAME}.puppetlabs.vm /etc/sysconfig/network"  \
       "You should set HOSTNAME=${NAME}.puppetlabs.vm in /etc/sysconfig/network"
 
 check "ping -c1 master.puppetlabs.vm"                               \
-      "Checking master name resolution"                             \
+      "Checking master name resolves and is pingable"               \
       "You should have an entry in /etc/hosts for master.puppetlabs.vm"
 
 check "ping -c1 ${NAME}.puppetlabs.vm"                              \


### PR DESCRIPTION
Currently, if the verify_classroom.sh script fails to ping the master by name, it prints an error that the master is not resolvable.  However, the ping failing may also be due to a network problem, rather than resolution.  This commit updates the check's text to indicate that the test is for both name resolution _and_ pingabililty.
