### PR TITLE
Added virtual classroom support to the module

### DIFF
--- a/modules/classroom/manifests/params.pp
+++ b/modules/classroom/manifests/params.pp
@@ -30,6 +30,9 @@ class classroom::params {
   # time servers to use if we've got network
   $time_servers = ['0.pool.ntp.org iburst', '1.pool.ntp.org iburst', '2.pool.ntp.org iburst', '3.pool.ntp.org']
 
+  # list of module repositorites that should be precreated for the virtual courses
+  $precreated_repositories = [ 'motd', 'helloworld', 'mongodb' ]
+
   # is this a student's tier3 agent in Architect?
   if $domain != 'puppetlabs.vm' {
     $role = 'tier3'
@@ -43,7 +46,7 @@ class classroom::params {
   }
 
   $download = "\n\nPlease download a new VM: http://downloads.puppetlabs.com/training/\n\n"
-  if versioncmp($::classroom_vm_release, '2.5') < 0 {
+  if $::classroom_vm_release and versioncmp($::classroom_vm_release, '2.5') < 0 {
     fail("Your VM is out of date. ${download}")
   }
 

--- a/modules/classroom/manifests/virtual/agent.pp
+++ b/modules/classroom/manifests/virtual/agent.pp
@@ -1,0 +1,4 @@
+class classroom::virtual::agent {
+
+
+}

--- a/modules/classroom/manifests/virtual/master.pp
+++ b/modules/classroom/manifests/virtual/master.pp
@@ -1,0 +1,35 @@
+class classroom::virtual::master (
+  $extra_repositories = undef,
+) inherits classroom::params {
+
+  File {
+    owner  => 'root',
+    group  => 'root',
+    mode   => '1777',
+  }
+
+  include git
+
+  user { 'classroom':
+    ensure     => present,
+    managehome => true,
+    password   => $classroom::params::password,
+  }
+
+  file { ['/var/repositories', '/etc/puppetlabs/puppet/modules']:
+    ensure => directory,
+  }
+
+  # Each repository represents a module
+  if $extra_repositories {
+    $repositories = flatten([$classroom::params::precreated_repositories, $extra_repositories])
+  } else {
+    $repositories = $classroom::params::precreated_repositories
+  }
+  classroom::master::repository { $repositories:
+    ensure      => present,
+    environment => false,
+    repo_user   => 'classroom',
+    clone_root  => '/etc/puppetlabs/puppet/modules'
+  }
+}

--- a/modules/classroom/templates/post-update.erb
+++ b/modules/classroom/templates/post-update.erb
@@ -2,10 +2,9 @@
 
 # clean up environment
 unset $(git rev-parse --local-env-vars)
-cd '/etc/puppetlabs/puppet/environments/<%= @name %>' || exit
+cd '<%= @clone_root %>/<%= @name %>' || exit
 
-echo "Updating Puppet Environment <%= @name %>"
+echo "Updating modulepath: <%= @name %>"
 
 git fetch --all
 git reset --hard origin/master
-


### PR DESCRIPTION
This simply adds two classes:
- `classroom::virtual::master`
- `classroom::virtual::agent`

For now, the students should classify their own nodes as needed. There's
significantly less automagic than in the ILT classrooms right now.

The `master` class will precreate repositories for all expected modules
on the student's master. If they'd like to add more, then can add
to the $extra_repositories parameter.

This will require @casharma to update the variable in
`classroom::params` to match the actual exercises.

Once approved, I'll bump the version and release a new version just in time for the class on Monday.
