### PR TITLE
Add a default value for allow_virtual on Packages.

### DIFF
--- a/modules/classroom/files/site.pp
+++ b/modules/classroom/files/site.pp
@@ -25,6 +25,9 @@ filebucket { 'main':
 # Make filebucket 'main' the default backup location for all File resources:
 File { backup => 'main' }
 
+# Specify a default value for the allow_virtual attribute on Packages.
+Package { allow_virtual => true }
+
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
 # http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on

--- a/modules/fundamentals/files/site.pp
+++ b/modules/fundamentals/files/site.pp
@@ -25,6 +25,9 @@ filebucket { 'main':
 # Make filebucket 'main' the default backup location for all File resources:
 File { backup => 'main' }
 
+# Specify a default value for the allow_virtual attribute on Packages.
+Package { allow_virtual => true }
+
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
 # http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on


### PR DESCRIPTION
This commit updates the version of site.pp on the training virtual machines to have Package
{ allow_virtual => true, }
This makes the (often confusing) deprecation warnings stop happening on puppet agent runs against the master.
