### PR TITLE
The new quest is now intelligent about not running multiple copies

### DIFF
--- a/modules/learning/files/tmux.conf
+++ b/modules/learning/files/tmux.conf
@@ -14,7 +14,9 @@ set-option -g status-left-length 20
 setw -g automatic-rename on
 
 # status right options
-set-option -g status-right 'Quest: #[fg=cyan]#(/root/bin/quest --list brief) #[fg=white]- Progress: #[fg=yellow]#(/root/bin/quest --progress brief) #[fg=white]Tasks. '
+# set-option -g status-right 'Quest: #[fg=cyan]#(/root/bin/quest --list brief) #[fg=white]- Progress: #[fg=yellow]#(/root/bin/quest --progress brief) #[fg=white]Tasks. '
+
+set-option -g status-right 'Quest: #[fg=cyan]#(cat /tmp/quest--listbrief.out) #[fg=white]- Progress: #[fg=yellow]#(cat /tmp/quest--progressbrief.out) #[fg=white]Tasks. '
 
 # refresh often
 set-option  -g status-interval 2

--- a/modules/userprefs/templates/bashrc.puppet.erb
+++ b/modules/userprefs/templates/bashrc.puppet.erb
@@ -45,10 +45,17 @@ function parse_git_dirty() {
 function parse_git_branch() {
   git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
 }
+
 export PS1="\[${ORANGE}\][\[${BOLD}${MAGENTA}\]\u@\h \[${GREEN}\]\w\[${BOLD}\]\$(is_on_git && [[ -n \$(git branch 2> /dev/null) ]] && echo \":\")\[${PURPLE}\]\$(parse_git_branch)\[${RESET}\]\[${ORANGE}\]]\[${RESET}\]# "
 
 <% if @hostname =~ /learn/ -%>
-export PROMPT_COMMAND='history -a; history -r'
+#- to be used with new 'quest' command and .tmux.conf
+function check_quest() {
+  (quest updatecache --list brief >/dev/null &)
+  (quest updatecache --progress brief >/dev/null &)
+}
+
+export PROMPT_COMMAND='history -a; history -r; check_quest'
 
 # If not running interactively, do not do anything
 [[ $- != *i* ]] && return

--- a/scripts/lvm/quest
+++ b/scripts/lvm/quest
@@ -1,4 +1,67 @@
 #!/bin/bash
+#
+# This script was written by Evan K Langlois and donated to PuppetLabs
+# without restrictions of any kind.  Comments to: uudruid74@gmail.com
+# Run with "resetlocks" for emergency cleanup.  The updatecache argument
+# is to just force an update of the caches, namely to be run from bash's
+# PROMPT_COMMAND so that tmux can just use the caches instead of wasting
+# cpu on running a command over and over that can only change when the
+# user runs a command anyway.
+#
 
-cd /root/.testing/
-/opt/puppet/bin/ruby /root/.testing/test.rb $* 2>/dev/null
+CMDLINE=`echo $* | tr -d ' '` 
+BASE=`basename $0`
+BUFFER="/tmp/${BASE}${CMDLINE}.out"
+LOCK="/tmp/${BASE}.lck"
+RUBY='/opt/puppet/bin/ruby'
+DIR='/root/.testing'
+TEST='test.rb'
+
+#- There is special behavior when run from tmux
+#- As long as a lock file exists, we use the previous output
+#- The cached output isn't used as long as there is no lock,
+#- meaning the command line completed.
+
+if [ "$1" == "updatecache" ] || \
+          [[ `cat /proc/$PPID/cmdline` =~ 'tmux' ]]; then
+  if [ "$1" == "updatecache" ]; then
+    echo OldCommand $*
+    shift
+    CMDLINE=`echo $* | tr -d ' '`
+    BUFFER="/tmp/${BASE}${CMDLINE}.out"
+    echo NewCommand $*
+    
+  fi
+  if [ -e $LOCK ]; then       #- lock exists
+    if [ -s $BUFFER ]; then   #- is not empty - use cached output
+      cat $BUFFER
+      exit
+    else                      #- generating cache
+                              #- let other task run
+      exit
+    fi
+  else                        #- no lock, run new copy
+    trap "rm -f $LOCK" EXIT
+    touch $LOCK
+  fi
+                              #- This part is run by tmux and cached
+  cd $DIR 
+  $RUBY $TEST $* 2>/dev/null | tee $BUFFER.part
+                              #- Only cache non-empty outputs
+  if [ -s "$BUFFER.part" ]; then
+      mv $BUFFER.part $BUFFER
+  fi
+else                          #- not run by tmux - super reset option
+    if [ "$1" == "resetlocks" ]; then
+      echo Killing all instances of $TEST and resetting lock
+      trap "rm -f /tmp/${BASE}*" EXIT
+      ps -ef | grep $RUBY | grep $TEST | awk  '{ print $2 }' \
+            | xargs kill 2>/dev/null
+      exit
+    else                      #- No caching, just run
+                              #- Manually run - original script
+      cd $DIR
+      $RUBY $TEST $* 2>/dev/null 
+    fi
+fi
+


### PR DESCRIPTION
of itself when the work would be redundant.  This fixes the massive
spawning issue where it's run constantly by tmux but takes longer
to run than expected.  This version of quest can stand on its own.

The new tmux.conf and .bashrc.puppet must be applied together, and
these rely on the new version of the quest script.  Basically, this
further reduces system load by having bash run quest from PROMPT_COMMAND
and tmux just reads the current cached output from /tmp.

To further fix the spawning issue you should also change
/etc/cron.d/default-add-all-nodes to run every 10 minutes or so as
it can take longer than 2 minutes (current setting) to run, but that
file isn't part of training!
