### PR TITLE
Write report stats to student's home directory

### DIFF
--- a/modules/classroom/files/process_reports.rb
+++ b/modules/classroom/files/process_reports.rb
@@ -12,7 +12,8 @@ require 'yaml'
 
 Puppet.initialize_settings
 
-datafile  = File.expand_path('~/puppetruns.yaml')
+username  = `who -m`.split.first
+datafile  = File.expand_path("~#{username}/puppetruns.yaml")
 reportdir = Puppet.settings[:reportdir]
 stats     = {}
 


### PR DESCRIPTION
This script is run via sudo, so we need to get the name of the logged in
user to derive the path for the output file. Otherwise, it just logs to
root's homedir and that's not terribly useful.

Fixes #COURSES-554
