### PR TITLE
Allow students to tail /var/log/messages

### DIFF
--- a/modules/classroom/files/sudoers.classroom
+++ b/modules/classroom/files/sudoers.classroom
@@ -1,3 +1,4 @@
 ALL ALL = (peadmin) NOPASSWD:ALL
 ALL ALL = (root) NOPASSWD:/usr/local/bin/process_reports.rb
 ALL ALL = (root) NOPASSWD:/opt/puppet/bin/rake
+ALL ALL = (root) NOPASSWD:/usr/bin/tail -f /var/log/messages, /usr/bin/tail /var/log/messages


### PR DESCRIPTION
This allows only no args or -f.

Fixes #COURSES-553
