### PR TITLE
This commit adds the declaration of classroom::master::sudoers to init.p...

### DIFF
--- a/modules/classroom/manifests/init.pp
+++ b/modules/classroom/manifests/init.pp
@@ -38,7 +38,10 @@ class classroom (
 
   # variables are available to included classes by the evil power of inheritance
   case $role {
-    'master' : { include classroom::master }
+    'master' : { 
+      include classroom::master 
+      include classroom::master::sudoers
+    }
     'agent'  : { include classroom::agent  }
     'proxy'  : { include classroom::proxy  }
     'tier3'  : { include classroom::tier3  }


### PR DESCRIPTION
...p.

Declaring classroom::master::sudoers adds configuration in /etc/sudoers.d to the Puppet Master node, so that students can connect from their agent nodes to the Master over ssh, and get sudo passwordless access to the peadmin account,
s is required for the Practitioner Course Mcollective lab at:
Orchestration/Lab-control_puppet/1
