### PR TITLE
Prevent students from breaking the master

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -4,6 +4,13 @@ version
 
 echo "This script will automate the setup of the Puppetlabs Training Classroom"
 echo
+
+if [ "`hostname`" == 'master.puppetlabs.vm' ]
+then
+  echo 'Do not run on the classroom master'
+  exit 1
+fi
+
 offer_bailout
 
 # backup /etc/hosts and /etc/sysconfig/network

--- a/scripts/classroom/verify_classroom.sh
+++ b/scripts/classroom/verify_classroom.sh
@@ -41,3 +41,8 @@ check "[[ '`grep processor /proc/cpuinfo | wc -l`' -gt '1' ]]"      \
 check "[[ \"`awk '/MemTotal/{print $2}' /proc/meminfo`\" -ge '1938740' ]]" \
       "Checking available memory for classroom Master"              \
       "You should give the virtual machine for the classroom Master at least 2GB of memory"
+
+DEFAULT='$1$jrm5tnjw$h8JJ9mCZLmJvIxvDLjw1M/'  # 'puppet'
+check "[[ '$(awk -F ':' '/^root/{print $2}' /etc/shadow)' != '$DEFAULT' ]]" \
+      "Verifying that the default password has been changed"           \
+      "You should change root's password before proceeding"


### PR DESCRIPTION
Fixes #TRAINVM-140

This bellows at the instructor if they haven't changed root password and prevents the setup script from running on the master
