### PR TITLE
Fail if Puppet is already installed

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -11,6 +11,13 @@ then
   exit 1
 fi
 
+puppet --version > /dev/null 2>&1
+if [ $? -eq 0 ]
+then
+  echo 'You appear to already have Puppet installed. Is this the Learning VM?'
+  exit 2
+fi
+
 offer_bailout
 
 # backup /etc/hosts and /etc/sysconfig/network


### PR DESCRIPTION
This should detenct when students show up with the LVM.

Fixes #TRAINVM-84
