### PR TITLE
Use the first network interface only.

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -27,7 +27,7 @@ BACKUP_DIR=$(mktemp -d)
 cp "$HOSTS" "$BACKUP_DIR"
 cp "$NETWORK" "$BACKUP_DIR"
 
-ipaddr=`hostname -I`
+ipaddr=`hostname -I | awk '{print $1}'`
 echo "Your IP address appears to be ${ipaddr}"
 echo "If this is not correct, cancel now."
 offer_bailout


### PR DESCRIPTION
This allows the script to work on machines with multiple interfaces
defined. This is common when running on VirtualBox and a host-only
interface is added to SSH into.

Fixes #TRAINVM-139
