### PR TITLE
Offer warning when a period is included

### DIFF
--- a/scripts/classroom/setup_classroom.sh
+++ b/scripts/classroom/setup_classroom.sh
@@ -36,6 +36,13 @@ while : ; do
   echo -n "Please choose a username: "
   read username
 
+  if [[ "$username" =~ \. ]]
+  then
+    echo 'WARNING: Periods in the username are unsupported in the classroom except'
+    echo 'WARNING: when creating a secondary agent in the Architect course.'
+    offer_bailout
+  fi
+
   [[ "$username" =~ ^[a-z0-9][a-z0-9._]+$ && "$username" =~ [a-z]+ && "$username" != "root" ]] && break
 
   echo "Usernames must be lowercase alphanumeric with at least one letter and not 'root'."


### PR DESCRIPTION
This is a warning only because we use the period in the Architect
course. It should be scary enough to prevent users in other courses from
doing dumb things though.

Fixes #TRAINVM-129
