### PR TITLE
Forward port global environment timeout

### DIFF
--- a/modules/classroom/manifests/agent/workdir.pp
+++ b/modules/classroom/manifests/agent/workdir.pp
@@ -35,11 +35,15 @@ define classroom::agent::workdir (
         replace => false,
       }
 
-      file { "${workdir}/environment.conf":
-        ensure  => file,
-        content => "environment_timeout = 0\n",
-        replace => false,
-      }
+      # https://docs.puppetlabs.com/puppet/latest/reference/environments_configuring.html#environmenttimeout
+      # suggests that this setting can be pushed up to puppet.conf globally.
+      # Initial testing appears to confirm that. If this proves problematic, then
+      # uncomment this resource and the relevant resource in classroom::master
+      # file { "${workdir}/environment.conf":
+      #   ensure  => file,
+      #   content => "environment_timeout = 0\n",
+      #   replace => false,
+      # }
 
       file { "${workdir}/modules":
         ensure => directory,

--- a/modules/classroom/manifests/master.pp
+++ b/modules/classroom/manifests/master.pp
@@ -39,10 +39,23 @@ class classroom::master (
     target => '/etc/puppetlabs/puppet/manifests',
   }
 
-  file { "/etc/puppetlabs/puppet/environments/production/environment.conf":
-    ensure  => file,
-    content => "environment_timeout = 0\n",
-    replace => false,
+  # https://docs.puppetlabs.com/puppet/latest/reference/environments_configuring.html#environmenttimeout
+  # Suggests that this setting can be pushed up to puppet.conf globally.
+  # Initial testing appears to confirm that. If this proves problematic, then
+  # uncomment this resource and the relevant resource in classroom::agent::workdir
+  # file { "/etc/puppetlabs/puppet/environments/production/environment.conf":
+  #   ensure  => file,
+  #   content => "environment_timeout = 0\n",
+  #   replace => false,
+  # }
+
+  # Ensure the environment cache is disabled and restart if needed
+  augeas {'puppet.conf.main':
+    context => '/files/etc/puppetlabs/puppet/puppet.conf/main',
+    changes => [
+      "set environment_timeout 0",
+    ],
+    notify  => Service['pe-httpd'],
   }
 
   augeas {'puppet.conf.environmentpath':


### PR DESCRIPTION
Original commit was #a4ec64f by @joshbeard

Docs at https://docs.puppetlabs.com/puppet/latest/reference/environments_configuring.html#environmenttimeout
and testing by Gabe & Gary seem to indicate that we can push the
environment timeout back up to global and omit the `environment.conf`
file.

`modulepath` should also default to `modules:$basemodulepath` per
https://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html#modulepath

Instructions to undo this commit in case of disaster are being added to
the Troubleshooting Guide.
