### PR TITLE
Gate the tier3 class to only old PE

### DIFF
--- a/modules/classroom/manifests/params.pp
+++ b/modules/classroom/manifests/params.pp
@@ -40,7 +40,7 @@ class classroom::params {
   $precreated_repositories = [ 'critical_policy', 'registry', 'profiles' ]
 
   # is this a student's tier3 agent in Architect?
-  if $domain != 'puppetlabs.vm' {
+  if (versioncmp($::pe_version, '3.4.0') < 0 and $domain != 'puppetlabs.vm') {
     $role = 'tier3'
   }
   else {


### PR DESCRIPTION
This class can cause problems if the domain fact returns an unexpected
value. This doesn't fix that problem, but it keeps it from affecting us
in 3.7. The class will be removed shortly, when we drop support for 3.3.
