### PR TITLE
Increase ngircd maximum nick length

### DIFF
--- a/modules/classroom/templates/ngircd.conf.erb
+++ b/modules/classroom/templates/ngircd.conf.erb
@@ -125,7 +125,7 @@
 	# Maximum length of an user nick name (Default: 9, as in RFC 2812).
 	# Please note that all servers in an IRC network MUST use the same
 	# maximum nick name length!
-	;MaxNickLength = 50
+	MaxNickLength = 50
 
 [Operator]
 	# [Operator] sections are used to define IRC Operators. There may be


### PR DESCRIPTION
Sometimes students like to go crazy and have really long hostnames.  This commit changes the configuration of ngircd so that students will be able to connect even if they have a fifty character hostname.
