### PR TITLE
Remove warning for allow_virtual change of default value

### DIFF
--- a/modules/learning/files/lvmguide/files/html/quests/resource_ordering.html
+++ b/modules/learning/files/lvmguide/files/html/quests/resource_ordering.html
@@ -280,8 +280,9 @@ Find the line that reads:</p>
 <p>Type the following code in above your file resource in file <code>/root/sshd.pp</code></p>
 
 <div class="highlight"><pre><code class="puppet"><span class="nc">package</span> <span class="p">{</span> <span class="s1">'openssh-server'</span><span class="p">:</span>
-  <span class="nt">ensure</span> <span class="p">=&gt;</span> <span class="ss">present</span><span class="p">,</span>
-  <span class="nt">before</span> <span class="p">=&gt;</span> <span class="nc">File</span><span class="p">[</span><span class="s1">'/etc/ssh/sshd_config'</span><span class="p">],</span>
+  <span class="nt">ensure</span>        <span class="p">=&gt;</span> <span class="ss">present</span><span class="p">,</span>
+  <span class="nt">before</span>        <span class="p">=&gt;</span> <span class="nc">File</span><span class="p">[</span><span class="s1">'/etc/ssh/sshd_config'</span><span class="p">],</span>
+  <span class="nt">allow_virtual</span> <span class="p">=&gt;</span> <span class="ss">false</span><span class="p">,</span>
 <span class="p">}</span>
 </code></pre></div>
 


### PR DESCRIPTION
If you follow the current tutorial as the allow_virtual default will be changed in future releases you find the next warning:

```
[root@learning ~]# puppet apply --noop sshd.pp 
Notice: Compiled catalog for learning.puppetlabs.vm in environment production in 0.47 seconds
Warning: The package type's allow_virtual parameter will be changing its default value from false to true in a future release. If you do not want to allow virtual packages, please explicitly set allow_virtual to false.
   (at /opt/puppet/lib/ruby/site_ruby/1.9.1/puppet/type.rb:816:in `set_default')
Notice: Finished catalog run in 0.37 seconds
[root@learning ~]# 
```

As a new joiner to puppet the tutorial should be warning free as it can scary new people.

The fix sets the default for allow_virtual to false and the warning disappears:

```
[root@learning ~]# puppet apply --noop sshd.pp 
Notice: Compiled catalog for learning.puppetlabs.vm in environment production in 0.49 seconds
Notice: Finished catalog run in 0.33 seconds
[root@learning ~]# 
```
