### PR TITLE
Fix management of environmentpath

### DIFF
--- a/modules/classroom/manifests/master/student_environment.pp
+++ b/modules/classroom/manifests/master/student_environment.pp
@@ -12,36 +12,39 @@ class classroom::master::student_environment inherits classroom::params {
     mode  => '0644',
   }
 
-  file { [
-    $environmentpath,
-    "${environment}",
-    "${environment}/manifests",
-    "${environment}/modules",
-  ]:
-    ensure => directory,
-  }
+  # we need this check because the $environmentpath doesn't exist until the
+  # node is classified as a PE Master, so we can't put files into it.
+  if defined(Class['puppet_enterprise::profile::master') {
+    file { [
+      $environment,
+      "${environment}/manifests",
+      "${environment}/modules",
+    ]:
+      ensure => directory,
+    }
 
-  file { "${environment}/manifests/site.pp":
-    ensure  => file,
-    source  => 'puppet:///modules/classroom/site.pp',
-    replace => false,
-  }
+    file { "${environment}/manifests/site.pp":
+      ensure  => file,
+      source  => 'puppet:///modules/classroom/site.pp',
+      replace => false,
+    }
 
-  # Ensure the environment cache is disabled and restart if needed
-  ini_setting {'environment_timeout':
-    ensure  => present,
-    path    => '/etc/puppetlabs/puppet/puppet.conf',
-    section => 'main',
-    setting => 'environment_timeout',
-    value   => '0',
-  }
+    # Ensure the environment cache is disabled and restart if needed
+    ini_setting {'environment_timeout':
+      ensure  => present,
+      path    => '/etc/puppetlabs/puppet/puppet.conf',
+      section => 'main',
+      setting => 'environment_timeout',
+      value   => '0',
+    }
 
-  # Ensure the environmentpath is configured and restart if needed
-  ini_setting {'environmentpath':
-    ensure  => present,
-    path    => '/etc/puppetlabs/puppet/puppet.conf',
-    section => 'main',
-    setting => 'environmentpath',
-    value   => $environmentpath,
+    # Ensure the environmentpath is configured and restart if needed
+    ini_setting {'environmentpath':
+      ensure  => present,
+      path    => '/etc/puppetlabs/puppet/puppet.conf',
+      section => 'main',
+      setting => 'environmentpath',
+      value   => $environmentpath,
+    }
   }
 }


### PR DESCRIPTION
The `puppet_enterprise` module manages only the directory portion of
the `environmentpath`, not any of the contents. We want to put starting
default content in place. Unfortunately, the `environmentpath` is
managed only when classified in the _PE Masters_ nodegroup, so we cannot
put contents into it until it's classified.

This introduces a possible parse order problem, but it will fail in the
direction of no action rather than a compile or enforcement failure.

Thanks to @beergeek for identifying the problem.

Fixes #COURSES-675 
