### PR TITLE
Increase ngircd maximum nick length to fifty characters

### DIFF
--- a/modules/classroom/templates/ngircd.conf.erb
+++ b/modules/classroom/templates/ngircd.conf.erb
@@ -125,7 +125,7 @@
 	# Maximum length of an user nick name (Default: 9, as in RFC 2812).
 	# Please note that all servers in an IRC network MUST use the same
 	# maximum nick name length!
-	;MaxNickLength = 15
+	MaxNickLength = 50
 
 [Operator]
 	# [Operator] sections are used to define IRC Operators. There may be


### PR DESCRIPTION
Some students like to have really elaborate names, over nine characters.  This change to the ngircd config file allows up to fifty characters.  I've tested that students' irssi applications can successfully connect to ngircd with over-nine-character nicks, and join the #advanced channel.
