### PR TITLE
remove second puppet run from learning_cleanup.sh

### DIFF
--- a/scripts/learning_cleanup.sh
+++ b/scripts/learning_cleanup.sh
@@ -1,8 +1,5 @@
 export PATH=$PATH:/opt/puppetlabs/bin/
 
-# Install docker module
-puppet module install garethr-docker --modulepath=/etc/puppetlabs/code/modules
-
 # Make sure it's ok to run puppet
 while [ -f /opt/puppetlabs/puppet/cache/state/agent_catalog_run.lock ]; do echo Waiting for Puppet Run to complete; sleep 10; done
 while ! curl -k -I https://localhost:8140/packages/ 2>/dev/null | grep "200 OK" > /dev/null; do echo Waiting for Puppet Server to start; sleep 10; done
@@ -10,8 +7,6 @@ echo Initializing Puppet Server
 sleep 60
 
 # Run puppet twice
-puppet agent -t
-
 puppet agent -t
 
 echo Puppet run completed


### PR DESCRIPTION
Now that the pe module has been fixed this isn't needed.
Also removed the docker module install now that there's
an r10k method implemented.