### PR TITLE
Update libvirt templates

### DIFF
--- a/cloud/libvirt/courses/vms/master.xml.erb
+++ b/cloud/libvirt/courses/vms/master.xml.erb
@@ -18,7 +18,7 @@
       <target dev='hda'/>
     </disk>
     <interface type='bridge'>
-      <source bridge='br0'/>
+      <source bridge='virbr0'/>
       <target dev='vnet<%= data[:id]%>'/>
     </interface>
     <graphics type='vnc' port='-1'/>

--- a/cloud/libvirt/courses/vms/master.xml.erb
+++ b/cloud/libvirt/courses/vms/master.xml.erb
@@ -1,7 +1,7 @@
 <domain type='kvm'>
-  <name><%= profile[:name] %></name>
+  <name><%= profile[:name] %><%= @options[:domain] %></name>
   <uuid></uuid>
-  <memory unit='GB'>1</memory>
+  <memory unit='GB'>6</memory>
   <vcpu>1</vcpu>
   <os>
     <type arch="x86_64">hvm</type>

--- a/cloud/libvirt/courses/volumes/master.xml.erb
+++ b/cloud/libvirt/courses/volumes/master.xml.erb
@@ -1,5 +1,5 @@
 <volume type='file'>
-  <name><%= data[:id] %>.qcow2</name>
+  <name><%= data[:id] %></name>
   <target>
     <path>/var/lib/libvirt/images/<%= data[:id] %>.qcow2</path>
     <format type='qcow2'/>


### PR DESCRIPTION
Changes name to fqdn for dnsmasq to work correctly
Bumps up memory on master
Stops using .qcow2 for volume object names