### PR TITLE
Fixed a consistency issue with a commented-out section of the file.

### DIFF
--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -35,7 +35,7 @@ mod 'dockeragent',
 
 mod 'pltraining/classroom'
 #mod 'classroom', 
-#  :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
+#  :git => 'https://github.com/puppetlabs/pltraining-classroom'
 
 mod 'pltraining/rbac', '0.0.4'
 #mod 'rbac', 


### PR DESCRIPTION
When switching to pulling the classroom module from GH instead of
the Forge, make sure it's the correct URL. It could be corrected by
the user at the time they switch from the Forge to GH, but this
fix will make the Puppetfile internally consistent until then.