### PR TITLE
Changed the name of the keypair used to log into MET VMs.

### DIFF
--- a/cloud/aws/courses/met.yaml
+++ b/cloud/aws/courses/met.yaml
@@ -2,36 +2,36 @@
 master:
   ami: "ami-a75b93c7"
   type: "m4.large"
-  key_name: "training"
+  key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 lon-agent-1234:
   ami: "ami-86e0ffe7"
   type: "t1.micro"
-  key_name: "training"
+  key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 pdx-agent-1743:
   ami: "ami-86e0ffe7"
   type: "t1.micro"
-  key_name: "training"
+  key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 pdx-agent-1663:
   ami: "ami-05cf2265"
   type: "t2.micro"
-  key_name: "training"
+  key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 nyc-agent-1234:
   ami: "ami-d2c924b2"
   type: "t2.micro"
-  key_name: "training"
+  key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 gitlab:
   ami: "ami-d2c924b2"
   type: "t2.micro"
-  key_name: "training"
+  key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"


### PR DESCRIPTION
We don't want to distribute training.pem to the SDPs using the
MET, so a new keypair was created in the AWS Console just for
the MET.