### PR TITLE
Add an instructor VM and call it `master`

### DIFF
--- a/cloud/aws/courses/infrastructure.yaml
+++ b/cloud/aws/courses/infrastructure.yaml
@@ -1,4 +1,10 @@
 ---
+master:
+  ami: "ami-c82bf6a8"
+  type: "m4.large"
+  key_name: "training"
+  security_group_ids:
+    - "sg-688b120f"
 student:
   ami: "ami-c82bf6a8"
   type: "m4.large"


### PR DESCRIPTION
The `vcmanager` tool expects one machine to be in the `master` role, for indexing purposes. In ID, we don't have that. Each student is standalone. So instead, we'll stand one machine up just like the others that the instructor can use for demos and exercises, but we'll call it the `master`.