### PR TITLE
Single VM artifact and token

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -189,7 +189,7 @@ end
 def box_to_ova(vm_name)
   box_name = "puppet-#{pe_version}-#{vm_name}-#{PTB_VERSION[:major]}.#{PTB_VERSION[:minor]}"
   puts %x{mkdir -p output/temp}
-  puts %x{cd output/temp; tar xvf ../#{box_name}-virtualbox.box}
+  puts %x{cd output/temp; tar xvf ../#{box_name}.box}
   open('output/temp/box.ovf','r') do |f|
     open('output/temp/box.ovf.temp','w') do |f2|
       f.each_line do |line|
@@ -201,6 +201,7 @@ def box_to_ova(vm_name)
   puts %x{cd output/temp; tar cvf #{box_name}.ova *.ovf *.vmdk *.json Vagrantfile}
   puts %x{mv output/temp/#{box_name}.ova output}
   puts %x{rm -rf output/temp}
+  puts %x{rm -f output/#{box_name}.box}
 end
 
 def build_vm(build_type, vm_name)

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -1,0 +1,5 @@
+yum -y install sudo
+/usr/src/build_scripts/base.sh
+/usr/src/build_scripts/time.sh
+/usr/src/build_scripts/pre_build.sh
+/usr/src/build_scripts/master_full.sh

--- a/scripts/master_build.sh
+++ b/scripts/master_build.sh
@@ -20,3 +20,6 @@ cd /usr/src/build_files
 rake master_build
 
 rm -rf /usr/src/build_files
+
+# Create token for deployer user
+echo 'puppetlabs' | HOME=/root /opt/puppetlabs/bin/puppet-access login deployer --lifetime 365d

--- a/templates/educationbuild.json
+++ b/templates/educationbuild.json
@@ -19,17 +19,8 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "output/{{user `vm_type`}}-ptb{{user `ptb_version`}}-{{.Provider}}.box",
+      "output": "output/puppet-{{user `pe_version`}}-{{user `vm_type`}}-{{user `ptb_version`}}-{{.Provider}}.box",
       "keep_input_artifact": true
-    },
-    { 
-      "type": "shell-local",
-      "script": "scripts/export-ova.sh",
-      "environment_vars": [
-        "VM_TYPE={{user `vm_type`}}",
-        "PE_VERSION={{user `pe_version`}}",
-        "PTB_VERSION={{user `ptb_version`}}"
-      ]
     }
   ],
   "provisioners": [

--- a/templates/educationbuild.json
+++ b/templates/educationbuild.json
@@ -19,7 +19,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "output/puppet-{{user `pe_version`}}-{{user `vm_type`}}-{{user `ptb_version`}}-{{.Provider}}.box",
+      "output": "output/puppet-{{user `pe_version`}}-{{user `vm_type`}}-{{user `ptb_version`}}.box",
       "keep_input_artifact": true
     }
   ],

--- a/templates/educationtest.json
+++ b/templates/educationtest.json
@@ -3,23 +3,23 @@
     {
       "vm_name": "{{ user `vm_type`}}",
       "type": "virtualbox-ovf",
-      "source_path": "output/{{ user `vm_type` }}-base-virtualbox/{{ user `vm_type` }}-base.ovf",
-      "ssh_username": "root",
-      "ssh_password": "puppet",
+      "source_path": "output/puppet-{{user `pe_version`}}-{{ user `vm_type` }}-{{user `ptb_version`}}.ova",
+      "ssh_username": "training",
+      "ssh_password": "training",
       "shutdown_command": "{{user `shutdown_command`}}",
       "output_directory": "output/{{ user `vm_type`}}-virtualbox/",
       "ssh_pty": "true",
       "headless": "true",
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--cpus", "1"],
+        ["modifyvm", "{{.Name}}", "--cpus", "{{user `vm_cores`}}"],
         ["modifyvm", "{{.Name}}", "--memory", "{{user `vm_memsize`}}"]
       ]
     }
   ],
   "post-processors": [
-    {
-      "type": "vagrant",
-      "output": "output/puppet-{{user `pe_version`}}-{{user `vm_type`}}-{{user `ptb_version`}}.box"
+    { 
+      "type": "shell-local",
+      "script": "echo 'Done'"
     }
   ],
   "provisioners": [
@@ -33,22 +33,11 @@
       "destination": "/usr/src/build_files"
     },
     {
-      "type": "shell",
-      "inline": ["useradd training",
-                 "echo \"training:training\" | chpasswd",
-                 "echo \"training ALL=(ALL) NOPASSWD: ALL\" >> /etc/sudoers",
-                 "mkdir -p /training/file_cache",
-                 "chown -R training:training /training"]
-    },
-    {
-      "type": "file",
-      "source": "build_files/",
-      "destination": "/usr/src/build_files"
-    },
-    {
       "environment_vars": [
         "PE_STATUS={{user `pe_status`}}",
         "PE_VERSION={{user `pe_version`}}",
+        "PE_FAMILY={{user `pe_family`}}",
+        "PRE_RELEASE={{user `pre_release`}}",
         "RUBY_LIB={{user `rubylib`}}",
         "TRAINING_REPO={{user `training_repo`}}",
         "TRAINING_BRANCH={{user `training_branch`}}",
@@ -56,28 +45,21 @@
       ],
       "execute_command": "{{.Vars}} sudo \"PATH=$PATH\" -E -S bash '{{.Path}}'",
       "scripts": [
-        "scripts/base.sh",
-        "scripts/pre_build.sh",
-        "scripts/{{user `vm_type`}}_build.sh",
-        "scripts/cleanup.sh",
-        "scripts/{{user `vm_type`}}_cleanup.sh",
-        "scripts/zerodisk.sh"
+        "scripts/test.sh"
       ],
       "type": "shell"
     }
   ],
   "variables": {
-    "shutdown_command": "sudo shutdown -P now",
-    "vm_type": "student",
-    "hostname": "student",
-    "vm_memsize": "1024",
-    "vm_disk_size": "10240",
-    "vm_cores": "1",
+    "hostname": "training",
     "pe_status": "release",
     "pe_version": "2016.2.0",
     "rubylib": "/usr/src/puppet/lib:/usr/src/facter/lib:/usr/src/hiera/lib",
     "training_branch": "master",
     "training_repo": "https://github.com/puppetlabs/education-builds.git",
+    "vm_type": "training",
+    "vm_memsize": "4096",
+    "vm_disk_size": "20480",
     "vm_cores": "2",
     "ptb_version": "5.7"
   }


### PR DESCRIPTION
There are two things conflated here:
1. Updates the build scripts to output a single artifact that is both a valid .ova and a valid vagrant box. This means tests run with vagrant can be sure to catch issues with the OVA. It also will help us move to releasing a vagrant box if we choose to do that.
2. Generates a token for the deployer user at the end of the master build.  This will preempt the long boot times.