### PR TITLE
Dynamic puppetfile

### DIFF
--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -16,36 +16,41 @@ moduledir './modules/'
 #   mod 'bootstrap', 
 #     :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
 #     :ref => 'ref-goes-here'
-
+branch = ENV['STABLE_MODULES'] =~ /yes/ ? 'release' : 'master'
+  
 
 mod 'bootstrap', 
-  :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
+  :git => 'https://github.com/puppetlabs/pltraining-bootstrap',
+  :ref => branch
 
 mod 'learning',
-  :git => 'https://github.com/puppetlabs/pltraining-learning'
-
-mod 'lms',
-  :git => 'https://github.com/puppetlabs/pltraining-lms'
+  :git => 'https://github.com/puppetlabs/pltraining-learning',
+  :ref => branch
 
 mod 'localrepo',
-  :git => 'https://github.com/puppetlabs/pltraining-localrepo'
+  :git => 'https://github.com/puppetlabs/pltraining-localrepo',
+  :ref => branch
 
 mod 'dockeragent',
-  :git => 'https://github.com/puppetlabs/pltraining-dockeragent'
+  :git => 'https://github.com/puppetlabs/pltraining-dockeragent',
+  :ref => branch
 
-mod 'pltraining/classroom'
-#mod 'classroom', 
-#  :git => 'https://github.com/puppetlabs/pltraining-classroom'
+if branch == 'release'
+  mod 'pltraining/classroom'
+  mod 'pltraining/rbac', '0.0.4'
+  mod 'pltraining/dirtree'
+  mod 'pltraining/userprefs'
+else
+  mod 'classroom', 
+    :git => 'https://github.com/puppetlabs/pltraining-classroom'
+  mod 'rbac', 
+    :git => 'https://github.com/puppetlabs/pltraining-rbac'
+  mod 'dirtree', 
+    :git => 'https://github.com/puppetlabs/pltraining-dirtree'
+  mod 'userprefs', 
+    :git => 'https://github.com/puppetlabs/pltraining-userprefs'
+end
 
-mod 'pltraining/rbac', '0.0.4'
-#mod 'rbac', 
-#  :git => 'https://github.com/puppetlabs/pltraining-rbac'
-
-#mod 'pltraining/userprefs'
-mod 'userprefs', 
-  :git => 'https://github.com/puppetlabs/pltraining-userprefs'
-
-mod 'pltraining/dirtree'
 
 mod 'puppetlabs/concat', '1.2.4'
 #mod 'concat', 

--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -21,19 +21,19 @@ branch = ENV['STABLE_MODULES'] =~ /yes/ ? 'release' : 'master'
 
 mod 'bootstrap', 
   :git => 'https://github.com/puppetlabs/pltraining-bootstrap',
-  :ref => branch
+  :ref => ENV['BOOTSTRAP_BRANCH'] || branch
 
 mod 'learning',
   :git => 'https://github.com/puppetlabs/pltraining-learning',
-  :ref => branch
+  :ref => ENV['LEARNING_BRANCH'] || branch
 
 mod 'localrepo',
   :git => 'https://github.com/puppetlabs/pltraining-localrepo',
-  :ref => branch
+  :ref => ENV['LOCALREPO_BRANCH'] || branch
 
 mod 'dockeragent',
   :git => 'https://github.com/puppetlabs/pltraining-dockeragent',
-  :ref => branch
+  :ref => ENV['DOCKERAGENT_BRANCH'] || branch
 
 if branch == 'release'
   mod 'pltraining/classroom'
@@ -42,13 +42,17 @@ if branch == 'release'
   mod 'pltraining/userprefs'
 else
   mod 'classroom', 
-    :git => 'https://github.com/puppetlabs/pltraining-classroom'
+    :git => 'https://github.com/puppetlabs/pltraining-classroom',
+    :ref => ENV['CLASSROOM_BRANCH'] || 'master'
   mod 'rbac', 
     :git => 'https://github.com/puppetlabs/pltraining-rbac'
+    :ref => ENV['RBAC_BRANCH'] || 'master'
   mod 'dirtree', 
     :git => 'https://github.com/puppetlabs/pltraining-dirtree'
+    :ref => ENV['DIRTREE_BRANCH'] || 'master'
   mod 'userprefs', 
     :git => 'https://github.com/puppetlabs/pltraining-userprefs'
+    :ref => ENV['USERPREFS_BRANCH'] || 'master
 end
 
 

--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -45,13 +45,13 @@ else
     :git => 'https://github.com/puppetlabs/pltraining-classroom',
     :ref => ENV['CLASSROOM_BRANCH'] || 'master'
   mod 'rbac', 
-    :git => 'https://github.com/puppetlabs/pltraining-rbac'
+    :git => 'https://github.com/puppetlabs/pltraining-rbac',
     :ref => ENV['RBAC_BRANCH'] || 'master'
   mod 'dirtree', 
-    :git => 'https://github.com/puppetlabs/pltraining-dirtree'
+    :git => 'https://github.com/puppetlabs/pltraining-dirtree',
     :ref => ENV['DIRTREE_BRANCH'] || 'master'
   mod 'userprefs', 
-    :git => 'https://github.com/puppetlabs/pltraining-userprefs'
+    :git => 'https://github.com/puppetlabs/pltraining-userprefs',
     :ref => ENV['USERPREFS_BRANCH'] || 'master'
 end
 

--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -52,7 +52,7 @@ else
     :ref => ENV['DIRTREE_BRANCH'] || 'master'
   mod 'userprefs', 
     :git => 'https://github.com/puppetlabs/pltraining-userprefs'
-    :ref => ENV['USERPREFS_BRANCH'] || 'master
+    :ref => ENV['USERPREFS_BRANCH'] || 'master'
 end
 
 

--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -16,7 +16,7 @@ moduledir './modules/'
 #   mod 'bootstrap', 
 #     :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
 #     :ref => 'ref-goes-here'
-branch = ENV['STABLE_MODULES'] =~ /yes/ ? 'release' : 'master'
+branch = ENV['STABLE_MODULES'] =~ /^(true|yes|y|Y)/ ? 'release' : 'master'
   
 
 mod 'bootstrap', 


### PR DESCRIPTION
The build currently uses the master branch of the pltraining modules.  This adds the option to use "release" which should be stable.

Modules which are published on the forge will be built with the stable version unless another is set and STABLE_MODULES is not enabled.

Releasable VM builds should be built with STABLE_MODULES=yes