### PR TITLE
Adds a userdata template to go with vcmanager

### DIFF
--- a/cloud/aws/userdata/default.erb
+++ b/cloud/aws/userdata/default.erb
@@ -1,11 +1,11 @@
 <% if profile.include? 'master_ip' -%>
 #cloud-config
 runcmd:
- - echo "<%= profile['master_ip'] %>  master.puppetlabs.vm" >> /etc/hosts
+ - echo "<%= profile['master_ip'] %>  master.puppetlabs.vm master puppet" >> /etc/hosts
 
 powershell: |
  <powershell>
   $file = "$env:windir\System32\drivers\etc\hosts"
-  "<%= profile['master_ip'] %>  master.puppetlabs.vm" | Add-Content -PassThru $file
+  "<%= profile['master_ip'] %>  master.puppetlabs.vm master puppet" | Add-Content -PassThru $file
  </powershell>
 <% end -%>

--- a/cloud/aws/userdata/default.erb
+++ b/cloud/aws/userdata/default.erb
@@ -1,0 +1,11 @@
+<% if profile.include? 'master_ip' -%>
+#cloud-config
+runcmd:
+ - echo "<%= profile['master_ip'] %>  master.puppetlabs.vm" >> /etc/hosts
+
+powershell: |
+ <powershell>
+  $file = "$env:windir\System32\drivers\etc\hosts"
+  "<%= profile['master_ip'] %>  master.puppetlabs.vm" | Add-Content -PassThru $file
+ </powershell>
+<% end -%>


### PR DESCRIPTION
Goes with https://github.com/puppetlabs/vcmanager/pull/43

If the profile has a `master_ip` set, then this generates a cross platform `#cloud-config` userdata script. The way it works is slightly hacky, but should be solid. The `run-cmd` key applies directly to cloud-init, so it will be executed on the first boot. The `powershell` key is arbitrary, it's just there to make it valid YAML.

EC2Config (the windows service) reads the same file and looks for the `<powershell>` tags. Everything between those tags is evaluated as a PowerShell script on the first boot.