### PR TITLE
Add session url

### DIFF
--- a/cloud/aws/notes.erb
+++ b/cloud/aws/notes.erb
@@ -1,3 +1,7 @@
+
+
+
+
 <%= @event[:notes] %>
 
 Your <%= @event[:course_name] %> classroom has been started.
@@ -6,6 +10,11 @@ You can access the classroom master using:
 
   * Address: <%= @event[:address] %>
   * Dashboard: <%= @event[:dashboard] %>
+  * Learndot Session URL: <%= event[:session_url] %>
 
 This machine will be shut down on <%= @event[:termination_date] %>.
 If you promise more time to students, please inform eduteam@puppet.com.
+
+
+
+


### PR DESCRIPTION
This is supposed to be captured and regurgitated in the `:notes` entry, but for some users it is not. Also, it seems like Learndot is stripping whitespace, so I added a whole bunch to validate that.