### PR TITLE
Set memory and cpus on student VMs on skytap.

### DIFF
--- a/cloud/skytap/PI.yaml
+++ b/cloud/skytap/PI.yaml
@@ -16,6 +16,8 @@ master_ports:
 student_template_id: 887849
 student_vm_id:
   - 12068212
+student_memory: 2048
+student_cpus: 2
 student_ports:
   - 80
 students:

--- a/cloud/skytap/PI.yaml
+++ b/cloud/skytap/PI.yaml
@@ -16,8 +16,8 @@ master_ports:
 student_template_id: 887849
 student_vm_id:
   - 12068212
-student_memory: 2048
-student_cpus: 2
+student_memory: 1024
+student_cpus: 1
 student_ports:
   - 80
 students:

--- a/cloud/skytap/fundamentals.yaml
+++ b/cloud/skytap/fundamentals.yaml
@@ -14,6 +14,8 @@ master_ports:
 student_template_id: 791817
 student_vm_id:
   - 9645730
+student_memory: 1024
+student_cpus: 1
 student_ports:
   - 22
   - 80

--- a/cloud/skytap/windows.yaml
+++ b/cloud/skytap/windows.yaml
@@ -14,8 +14,8 @@ master_ports:
 student_template_id: 887849
 student_vm_id:
   - 12068212
-student_memory: 2048
-student_cpus: 2
+student_memory: 1024
+student_cpus: 1
 student_ports:
   - 80
 students:

--- a/cloud/skytap/windows.yaml
+++ b/cloud/skytap/windows.yaml
@@ -14,6 +14,8 @@ master_ports:
 student_template_id: 887849
 student_vm_id:
   - 12068212
+student_memory: 2048
+student_cpus: 2
 student_ports:
   - 80
 students:


### PR DESCRIPTION
Windows VMs were defaulting to 2gb anyway, so this lets us use 2 cores
since it costs the same in skytap.