### PR TITLE
Properly fail if packer fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -159,6 +159,8 @@ def call_packer(template, args={}, var_file=nil)
     while (line = io.gets) do
       puts line
     end
+    io.close
+    fail "ERROR: packer build failed" unless $?.success?
   end
 end
 


### PR DESCRIPTION
The build was exiting 0 even when it failed. This causes it to actually fail on failures.