### PR TITLE
(TRAINTECH-1133) Replace general contribution guidelines with link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+Contribution Guidelines
+=======================
+
+## How to contribute
+
+Please refer to our [contribution
+guidelines](https://github.com/puppetlabs/edu-documentation/blob/master/CONTRIBUTING.md)
+documentation for general information on contributing to Puppet Education
+projects.
+
+# Additional Resources
+
+* [Puppet community guidelines](https://docs.puppet.com/community/community_guidelines.html)
+* [Bug tracker (Jira)](https://tickets.puppetlabs.com)
+* [Contributor License Agreement](http://links.puppet.com/cla)
+* [General GitHub documentation](https://help.github.com/)
+* [GitHub pull request documentation](https://help.github.com/articles/about-pull-requests/)


### PR DESCRIPTION
To ensure a consistent and well-documented contribution process across
Puppet Education project repositories, add a CONTRIBUTING.md file with
a link to the general contributing guidelines.