### PR TITLE
(TRAINTECH-1342) Update skytap templates for 6.1

### DIFF
--- a/cloud/skytap/PI.yaml
+++ b/cloud/skytap/PI.yaml
@@ -1,7 +1,7 @@
 ---
 title: Puppetizing Infrastructure
 domain_name: puppetlabs.vm
-master_template_id: 1108697
+master_template_id: 1142745
 master_memory: 16384
 master_cpus: 8
 master_name: master

--- a/cloud/skytap/fundamentals.yaml
+++ b/cloud/skytap/fundamentals.yaml
@@ -1,7 +1,7 @@
 ---
 title: Fundamentals Classroom
 domain_name: puppetlabs.vm
-master_template_id: 1108697
+master_template_id: 1142745
 master_memory: 8192
 master_cpus: 4
 master_name: master
@@ -11,9 +11,9 @@ master_ports:
   - 3000
   - 9090
   - 9091
-student_template_id: 1108829
+student_template_id: 1142745
 student_vm_id:
-  - 21273264
+  - 22900684
 student_memory: 1024
 student_cpus: 1
 student_ports:

--- a/cloud/skytap/infrastructure.yaml
+++ b/cloud/skytap/infrastructure.yaml
@@ -1,7 +1,7 @@
 ---
 title: Infrastructure Design
 domain_name: puppetlabs.vm
-master_template_id: 1108697
+master_template_id: 1142745
 master_memory: 8192
 master_cpus: 4
 master_name: master
@@ -14,9 +14,9 @@ master_ports:
   - 40080
   - 9090
   - 9091
-student_template_id: 1108829
+student_template_id: 1142741
 student_vm_id:
-  - 21273264
+  - 22900684
 student_ports:
   - 22
   - 80

--- a/cloud/skytap/windows.yaml
+++ b/cloud/skytap/windows.yaml
@@ -1,7 +1,7 @@
 ---
 title: Windows Essentials
 domain_name: puppetlabs.vm
-master_template_id: 1108697
+master_template_id: 1142745
 master_memory: 8192
 master_cpus: 4
 master_name: master


### PR DESCRIPTION
Skytap templates need to be updated to use the 6.1 master and
training VMs.

New VM builds have been uploaded and saved as templates per
https://confluence.puppetlabs.com/display/EDU/How+to+set+up+Skytap
This change replaces the old template and VM ids for the master
and student VMs with the IDs of the new templates.