### PR TITLE
(maint) Tag the building instance properly

### DIFF
--- a/templates/awsbuild.json
+++ b/templates/awsbuild.json
@@ -7,7 +7,13 @@
       "instance_type": "m3.large",
       "ssh_username": "centos",
       "ami_name": "PE-{{user `pe_version`}}-{{ user `vm_type`}}-{{ user `ptb_version`}}-{{isotime \"Jan02-0304\" }}",
-      "ssh_pty": "true"
+      "ssh_pty": "true",
+      "run_tags":  {
+        "created_by": "eduteam",
+        "department": "EDU",
+        "project": "vm_publish",
+        "lifetime": "1h"
+      }
     }
   ],
   "provisioners": [


### PR DESCRIPTION
If we don't tag the instance as it is building, then the AWS Reaper will
indiscriminately murder it at some indeterminate time before it
completes. This allows it to live through completion.