### PR TITLE
(MAINT) Use legacy branch of pltrainign-bootstrap

### DIFF
--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -18,7 +18,8 @@ moduledir './modules/'
 #     :ref => 'ref-goes-here'
 
 mod 'bootstrap',
-  :git => 'https://github.com/puppetlabs/pltraining-bootstrap'
+  :git => 'https://github.com/puppetlabs/pltraining-bootstrap',
+  :ref => 'legacy'
 
 mod 'localrepo',
   :git => 'https://github.com/puppetlabs/pltraining-localrepo'


### PR DESCRIPTION
Modify the build_files/Puppetfile to use the legacy branch of the
pltraining-bootstrap repository for builds until we can switch entirely
to the new build process implemented in the master branch of that
repository. This will allow us to continue using existing Jenkins build
pipelines unless/until those are adapted and tested against the new
build process.