### PR TITLE
(MAINT) Add saz/sudo dependency to Puppetfile

### DIFF
--- a/build_files/Puppetfile
+++ b/build_files/Puppetfile
@@ -73,6 +73,7 @@ mod 'garethr/docker'
 mod 'razorsedge/network'
 mod 'puppet/archive'
 mod 'puppetlabs/powershell'
+mod 'saz/sudo'
 
 # Dependencies for CIAB
 mod 'puppetlabs/firewall'


### PR DESCRIPTION
We need to add the sudo dependency to support: https://github.com/puppetlabs/pltraining-bootstrap/commit/218f994b66dbef56166a6238af533cc1b2c99349