### PR TITLE
(maint) Display a warning about auto suspend

### DIFF
--- a/cloud/skytap/virtualclassroom.rb
+++ b/cloud/skytap/virtualclassroom.rb
@@ -164,3 +164,6 @@ publish_all_vms = create_publish_set( environment['id'], all_vms, 'Instructor Da
 
 # Output the student URLs
 puts output_classroom(environment['id']).to_yaml
+  
+STDERR.puts "Don't forget to ensure that auto-suspend is disabled!"
+  


### PR DESCRIPTION
This prints a warning to STDERR. This means that you can still redirect output to a file and the warning will still display on the console without corrupting the file.