### PR TITLE
(MAINT) Delete the /tmp directory in cleanup

### DIFF
--- a/build_files/Rakefile
+++ b/build_files/Rakefile
@@ -300,6 +300,7 @@ def remove_installer_files
   FileUtils.rm_rf([
     '/root/puppet-enterprise',
     Dir.glob('/root/puppet-enterprise*'),
+    Dir.glob('/tmp/*'),
     '/etc/yum.repos.d/puppet_enterprise.repo',
     '/usr/src/installer'
   ])


### PR DESCRIPTION
This fixed a regression I believe was introduced in
https://github.com/puppetlabs/education-builds/pull/830 that skipped
deleting the /tmp directory in the cleanup step. This added about 0.5GB
to the final OVA size.