### PR TITLE
(maint) Add PI class codes for ILT courses

### DIFF
--- a/cloud/aws/codes.yaml
+++ b/cloud/aws/codes.yaml
@@ -13,3 +13,6 @@
 "Virtual Puppetizing Infrastructure 1": "puppetize-virtual-classroom-1"
 "Virtual Puppetizing Infrastructure 2": "puppetize-virtual-classroom-2"
 "Virtual Puppetizing Infrastructure 3": "puppetize-virtual-classroom-3"
+"Puppetizing Infrastructure 1": "puppetize-virtual-classroom-1"
+"Puppetizing Infrastructure 2": "puppetize-virtual-classroom-2"
+"Puppetizing Infrastructure 3": "puppetize-virtual-classroom-3"


### PR DESCRIPTION
Added missing codes for PI ILT classes. Still need to temporarily modify
the course name in Learndot so vcmanager starts the instances in the
correct virtual classroom, e.g. linked to one of the three Guacamole instances.