### PR TITLE
LEARNVM-624 Put peristent modules in non-env dir

### DIFF
--- a/build_files/Puppetfile.learning
+++ b/build_files/Puppetfile.learning
@@ -1,5 +1,5 @@
 forge "http://forge.puppetlabs.com"
-moduledir '/etc/puppetlabs/code/environments/production/modules'
+moduledir '/etc/puppetlabs/code/modules'
 
 # The following are modules to be installed on the Learning VM and persist
 # after the build process.

--- a/build_files/Rakefile
+++ b/build_files/Rakefile
@@ -363,10 +363,10 @@ end
 
 desc "Main"
 task :main do
-    install_r10k
-    install_build_dependency_modules
-    apply_bootstrap
-    install_persistent_modules if File.exist?("./Puppetfile.#{VM_TYPE}")
+  install_r10k
+  install_build_dependency_modules
+  apply_bootstrap
+  install_persistent_modules if File.exist?("./Puppetfile.#{VM_TYPE}")
   if ["learning", "master", "student", "training"].include? VM_TYPE
     create_access_token
     set_vm_version_file


### PR DESCRIPTION
Put the learning vm persistent modules used to support the quest tool in
the /etc/puppetlabs/code/modules directory rather than production
environment modules directory so that they won't be overwritten by
deploys done in the control-repo quest.