### PR TITLE
(maint) Remove trim modifier

### DIFF
--- a/cloud/aws/notes.erb
+++ b/cloud/aws/notes.erb
@@ -8,17 +8,17 @@ You can access the classroom master using:
   * Dashboard: <%= @event[:dashboard] %>
   * Zoom URL: <%= @event[:session_url] %>
 
-<% if @event[:instance_data] -%>
+<% if @event[:instance_data] %>
 Please distribute the Windows instance IP address and Administrator password
 to each student as needed. To log in to a Windows instance, open an RDP client
 and enter the listed IP address.
 
-<% @event[:instance_data].each do |instance, password_data| -%>
-<% unless password_data['password'].nil? -%>
+<% @event[:instance_data].each do |instance, password_data| %>
+<% unless password_data['password'].nil? %>
 <%= password_data['name'] %>: <%= password_data['public_ip'] %> / <%= password_data['password'] %>
-<% end -%>
-<% end -%>
-<% end -%>
+<% end %>
+<% end %>
+<% end %>
 
 This machine will be shut down on <%= @event[:termination_date] %>.
 If you promise more time to students, please inform eduteam@puppet.com.


### PR DESCRIPTION
The released version of `vcmanager` doesn't have trim enabled, so this breaks hard.