### PR TITLE
Add newline to hosts file

### DIFF
--- a/cloud/aws/userdata/default.erb
+++ b/cloud/aws/userdata/default.erb
@@ -6,6 +6,6 @@ runcmd:
 powershell: |
  <powershell>
   $file = "$env:windir\System32\drivers\etc\hosts"
-  "<%= profile['master_ip'] %>  master.puppetlabs.vm master puppet" | Add-Content -PassThru $file
+  "\n<%= profile['master_ip'] %>  master.puppetlabs.vm master puppet" | Add-Content -PassThru $file
  </powershell>
 <% end -%>

--- a/cloud/aws/userdata/default.erb
+++ b/cloud/aws/userdata/default.erb
@@ -6,6 +6,6 @@ runcmd:
 powershell: |
  <powershell>
   $file = "$env:windir\System32\drivers\etc\hosts"
-  "\n<%= profile['master_ip'] %>  master.puppetlabs.vm master puppet" | Add-Content -PassThru $file
+  "`r`n<%= profile['master_ip'] %>  master.puppetlabs.vm master puppet" | Add-Content -PassThru $file
  </powershell>
 <% end -%>


### PR DESCRIPTION
The Windows default hosts file doesn't appear to end with a newline, so let's add one.

TRAINTECH-1599 #resolved #time 10m