### PR TITLE
Update MET AMIs to HVM

### DIFF
--- a/cloud/aws/courses/met.yaml
+++ b/cloud/aws/courses/met.yaml
@@ -9,28 +9,28 @@ master:
 lon-agent-1324:
   description: Official Ubuntu 14.04 LTS
   ami: "ami-3b199243"
-  type: "t2.micro"
+  type: "t1.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 pdx-agent-1743:
   description: Official Ubuntu 14.04 LTS
   ami: "ami-3b199243"
-  type: "t2.micro"
+  type: "t1.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 pdx-agent-1663:
   description: Official CentOS 6.x
   ami: "ami-8b44f2f3"
-  type: "t2.micro"
+  type: "t1.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 nyc-agent-4163:
   description: Official CentOS 7.x
   ami: "ami-75bb700d"
-  type: "t2.micro"
+  type: "t1.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"

--- a/cloud/aws/courses/met.yaml
+++ b/cloud/aws/courses/met.yaml
@@ -1,36 +1,42 @@
 ---
 master:
+  description: Monolithic Puppet Master VM
   ami: "ami-a75b93c7"
   type: "m4.large"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 lon-agent-1324:
-  ami: "ami-86e0ffe7"
+  description: Official Ubuntu 14.04 LTS
+  ami: "ami-3b199243"
   type: "t2.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 pdx-agent-1743:
-  ami: "ami-86e0ffe7"
+  description: Official Ubuntu 14.04 LTS
+  ami: "ami-3b199243"
   type: "t2.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 pdx-agent-1663:
-  ami: "ami-05cf2265"
+  description: Official CentOS 6.x
+  ami: "ami-8b44f2f3"
   type: "t2.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 nyc-agent-4163:
-  ami: "ami-d2c924b2"
+  description: Official CentOS 7.x
+  ami: "ami-75bb700d"
   type: "t2.micro"
   key_name: "met"
   security_group_ids:
     - "sg-ee9abc89"
 gitlab:
-  ami: "ami-d2c924b2"
+  description: Official CentOS 7.x
+  ami: "ami-75bb700d"
   type: "t2.medium"
   key_name: "met"
   security_group_ids:


### PR DESCRIPTION
Also add a `description` key to the yaml file to help future updates.
This should not affect any tooling, as we don't use that key for
anything.

Note that this drops the requirement specificity from eg "CentOS 7.2" to "CentOS 7.x". This is so we can use the official instance. Flag if that's not acceptable.

SDPONBOARD-150 #resolved #time 90m